### PR TITLE
Menu breakpoint

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -31,7 +31,7 @@ function siteorigin_north_settings_init(){
 					'type' => 'media',
 					'label' => __('Logo', 'siteorigin-north'),
 					'description' => __('Logo displayed in your masthead.', 'siteorigin-north')
-				),				
+				),
 				'retina_logo' => array(
 					'type' => 'media',
 					'label' => __('Retina Logo', 'siteorigin-north'),
@@ -157,7 +157,11 @@ function siteorigin_north_settings_init(){
 					'type' => 'text',
 					'label' => __('Responsive Menu Text', 'siteorigin-north'),
 				),
-
+				'menu_breakpoint' => array(
+					'label' => __('Menu Breakpoint', 'siteorigin-north'),
+					'type' => 'text',
+					'description' => __('Screen width in px.', 'siteorigin-north')
+				),
 				'fitvids' => array(
 					'type' => 'checkbox',
 					'label' => __('Use Fitvids', 'siteorigin-north'),
@@ -257,6 +261,48 @@ function siteorigin_north_settings_custom_css($css){
 add_filter( 'siteorigin_settings_custom_css', 'siteorigin_north_settings_custom_css' );
 
 /**
+ * Add CSS for mobile menu breakpoint
+ */
+function siteorigin_north_menu_breakpoint_css() {
+
+	$breakpoint = siteorigin_setting( 'responsive_menu_breakpoint' );
+
+	$css = '<style type="text/css" id="siteorigin-mobile-menu-css">' . "\t" .
+	'/* responsive menu */' . "\t" .
+	'@media screen and (max-width: ' . $breakpoint  . 'px) {' . "\t" .
+		'body.responsive .main-navigation #mobile-menu-button {' .
+			'display: inline-block;' .
+		'}' . "\t" .
+		'body.responsive .main-navigation ul {' .
+			'display: none;' .
+		'}' . "\t" .
+		'body.responsive .main-navigation .north-icon-search {' .
+			'display: none;' .
+		'}' . "\t" .
+		'.main-navigation #mobile-menu-button {' .
+			'display: none;' .
+		'}' . "\t" .
+		'.main-navigation ul {' .
+			'display: inline-block;' .
+		'}' . "\t" .
+		'.main-navigation .north-icon-search {' .
+			'display: inline-block;' .
+		'}' . "\t" .
+	'}' . "\t" .
+	'@media screen and (min-width: ' . ( 1 + $breakpoint ) . 'px) {' . "\t" .
+		'body.responsive #mobile-navigation {' .
+			'display: none !important;' .
+			'}' . "\t" .
+		'}' . "\t" .
+	'</style>';
+
+	echo $css;
+
+}
+add_action( 'wp_head', 'siteorigin_north_menu_breakpoint_css' );
+
+
+/**
  * Add default settings.
  *
  * @param $defaults
@@ -283,6 +329,7 @@ function siteorigin_north_settings_defaults( $defaults ){
 	$defaults['navigation_scroll_to_top'] = true;
 
 	$defaults['responsive_fitvids'] = true;
+	$defaults['responsive_menu_breakpoint'] = '600';
 	$defaults['responsive_menu_text'] = __('Menu', 'siteorigin-north');
 
 	$defaults['blog_featured_archive'] = true;

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -59,7 +59,7 @@
 					left: 100%;
 				}
 			}
-			
+
 			a {
 				box-sizing: border-box;
 				white-space: nowrap;
@@ -91,13 +91,13 @@
 			display: block;
 		}
 	}
-	
+
 	li {
 		position: relative;
 
 		&:hover > a,
 		&.focus > a {
-			
+
 		}
 	}
 
@@ -176,19 +176,6 @@
 		top: 2px
 	}
 
-	@media screen and (max-width: 600px) {
-		#mobile-menu-button {
-			display: inline-block;
-		}
-
-		ul {
-			display: none;
-		}
-
-		.north-icon-search {
-			display: none;
-		}
-	}
 }
 
 #header-search {
@@ -341,9 +328,6 @@
 		}
 	}
 
-	@media screen and (min-width: 601px) {
-		display: none !important;
-	}
 }
 
 .comment-navigation,


### PR DESCRIPTION
Implements enhancement #8 

Deleted SCSS that dealt with mobile menu.
Added option for menu breakpoint.
Inserted mobile menu styles in `<head>` using `wp_head` action hook.
