### PR TITLE
Update cart

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -764,18 +764,16 @@ function siteorigin_north_settings_custom_css($css){
 	.woocommerce table.shop_table .cart_totals .amount {
 	color: ${branding_accent};
 	}
-	.woocommerce table.shop_table button {
+	.woocommerce table.shop_table .button {
 	.font( ${fonts_headings} );
-	}
-	.woocommerce table.shop_table button.checkout-button {
-	background: ${branding_accent};
-	border: 1px solid ${branding_accent};
-	}
-	.woocommerce table.shop_table button.button,.woocommerce table.shop_table button.button-continue-shopping {
 	border: 1px solid ${fonts_text_dark};
 	color: ${fonts_text_dark};
 	}
-	.woocommerce table.shop_table button:hover {
+	.woocommerce table.shop_table .button.checkout-button {
+	background: ${branding_accent};
+	border: 1px solid ${branding_accent};
+	}
+	.woocommerce table.shop_table .button:hover {
 	background: ${branding_accent_dark};
 	border-color: ${branding_accent_dark};
 	}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -792,10 +792,10 @@ function siteorigin_north_settings_custom_css($css){
 	background: ${branding_accent_dark};
 	}
 	.main-navigation .shopping-cart:hover .shopping-cart-count {
-	background: ${branding_accent_dark};
+	background: ${branding_accent_dark} padding-box;
 	}
 	.main-navigation .shopping-cart .shopping-cart-count {
-	background: ${branding_accent};
+	background: ${branding_accent} padding-box;
 	}
 	.widget_shopping_cart_content .cart_list .mini_cart_item .mini_cart_details .mini_cart_product {
 	color: ${fonts_text_dark};

--- a/sass/woocommerce/_cart.scss
+++ b/sass/woocommerce/_cart.scss
@@ -120,7 +120,7 @@
 				}
 			}
 
-			button {
+			.button {
 				border-radius: 0px;
 				font-size: 0.85em;
 				padding: 10px;
@@ -128,18 +128,20 @@
 				box-shadow: inset 0 0 1px rgba(0, 0, 0, 0.25);
 				font-family: $font__headings;
 				@include transition(0.085s);
+				background: transparent;
+				border: 1px solid $color__text_dark;
+				color: $color__text_dark;
+
+				&.button-continue-shopping {
+					text-decoration: none;
+					text-transform: uppercase;
+					font-weight: normal;
+				}
 
 				&.checkout-button {
 					background: $color__primary_accent;
 					border: 1px solid $color__primary_accent;
 					color: #fff;
-				}
-
-				&.button,
-				&.button-continue-shopping {
-					background: transparent;
-					border: 1px solid $color__text_dark;
-					color: $color__text_dark;
 				}
 
 				&:hover {

--- a/sass/woocommerce/_cart.scss
+++ b/sass/woocommerce/_cart.scss
@@ -225,8 +225,7 @@
 			}
 
 			.shopping-cart-count {
-				background: $color__primary_accent_dark;
-				background-clip: padding-box;
+				background: $color__primary_accent_dark padding-box;
 			}
 		}
 
@@ -237,10 +236,9 @@
 			padding: 3px 5px;
 			border: 2px solid #fff;
 			border-radius: 9px;
-			background: $color__primary_accent;
+			background: $color__primary_accent padding-box;
 			color: #fff;
 			font-size: 9px;
-			background-clip: padding-box;
 		}
 
 		.shopping-cart-dropdown {

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -460,8 +460,7 @@
     background: #a94346;
     color: #fff; }
   .main-navigation .shopping-cart:hover .shopping-cart-count {
-    background: #a94346;
-    background-clip: padding-box; }
+    background: #a94346 padding-box; }
   .main-navigation .shopping-cart .shopping-cart-count {
     position: relative;
     left: -11px;
@@ -469,10 +468,9 @@
     padding: 3px 5px;
     border: 2px solid #fff;
     border-radius: 9px;
-    background: #c75d5d;
+    background: #c75d5d padding-box;
     color: #fff;
-    font-size: 9px;
-    background-clip: padding-box; }
+    font-size: 9px; }
   .main-navigation .shopping-cart .shopping-cart-dropdown {
     width: 350px;
     right: 0; }

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -387,7 +387,7 @@
       color: #c75d5d; }
     .woocommerce table.shop_table .cart_totals .wc-proceed-to-checkout {
       display: none; }
-  .woocommerce table.shop_table button {
+  .woocommerce table.shop_table .button {
     border-radius: 0px;
     font-size: 0.85em;
     padding: 10px;
@@ -396,24 +396,27 @@
     font-family: "Montserrat", sans-serif;
     -webkit-transition: 0.085s;
     -moz-transition: 0.085s;
-    transition: 0.085s; }
-    .woocommerce table.shop_table button.checkout-button {
+    transition: 0.085s;
+    background: transparent;
+    border: 1px solid #292929;
+    color: #292929; }
+    .woocommerce table.shop_table .button.button-continue-shopping {
+      text-decoration: none;
+      text-transform: uppercase;
+      font-weight: normal; }
+    .woocommerce table.shop_table .button.checkout-button {
       background: #c75d5d;
       border: 1px solid #c75d5d;
       color: #fff; }
-    .woocommerce table.shop_table button.button, .woocommerce table.shop_table button.button-continue-shopping {
-      background: transparent;
-      border: 1px solid #292929;
-      color: #292929; }
-    .woocommerce table.shop_table button:hover {
+    .woocommerce table.shop_table .button:hover {
       background: #a94346;
       color: #fff;
       border-color: #a94346;
       box-shadow: none; }
     @media (max-width: 768px) {
-      .woocommerce table.shop_table button {
+      .woocommerce table.shop_table .button {
         margin-top: 0.5em; }
-        .woocommerce table.shop_table button[name="apply_coupon"] {
+        .woocommerce table.shop_table .button[name="apply_coupon"] {
           margin-top: 0; } }
 
 #mobile-navigation .shopping-cart-link {

--- a/woocommerce/cart/cart.php
+++ b/woocommerce/cart/cart.php
@@ -140,10 +140,10 @@ do_action( 'woocommerce_before_cart' ); ?>
 							</div>
 						<?php } ?>
 
-						<button class="button-continue-shopping"  href="<?php echo wc_get_page_permalink( 'shop' ); ?>"><?php esc_attr_e( 'Continue Shopping', 'siteorigin-north' ) ?></button>
-						<button type="submit" class="button" name="update_cart"><?php esc_attr_e( 'Update Cart', 'siteorigin-north' ); ?></button>
+						<a class="button-continue-shopping button"  href="<?php echo wc_get_page_permalink( 'shop' ); ?>"><?php esc_attr_e( 'Continue Shopping', 'siteorigin-north' ) ?></a>
+						<input type="submit" class="button" name="update_cart" value="<?php esc_attr_e( 'Update Cart', 'siteorigin-north' ); ?>">
 
-						<button type="submit" class="checkout-button" name="proceed" value="1"><span class="north-icon-cart"></span> <?php esc_attr_e( 'Checkout', 'siteorigin-north' ); ?></button>
+						<button type="submit" class="checkout-button button" name="proceed" value="1"><span class="north-icon-cart"></span> <?php esc_attr_e( 'Checkout', 'siteorigin-north' ); ?></button>
 
 						<?php do_action( 'woocommerce_cart_actions' ); ?>
 


### PR DESCRIPTION
Fixed bug #124

Fixed the `background-clip` for masthead cart icon. This was not getting applied when custom accent colors were picked.
Fixed the Continue Shopping link by using `a` element instead of `button`.
The Update Cart button was also not working. I fixed this by changing the `button` element to `input` element.