### PR TITLE
Removed duplicate wp_is_mobile() check

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -51,10 +51,6 @@ function siteorigin_north_body_classes( $classes ) {
 		$classes[] = 'sticky-menu';
 	}
 
-	if( wp_is_mobile() ) {
-		$classes[] = 'is_mobile';
-	}
-
 	return $classes;
 }
 endif;


### PR DESCRIPTION
This was not being used. Let's stick with the newly added one. https://github.com/siteorigin/siteorigin-north/blob/develop/inc/extras.php#L42