### PR TITLE
Reworked sticky navigation to be less js dependent

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -43,12 +43,16 @@ function siteorigin_north_body_classes( $classes ) {
 		$classes[] = 'is-mobile-device';
 	}
 
-	if( !is_active_sidebar('main-sidebar') ) {
+	if( ! is_active_sidebar( 'main-sidebar' ) ) {
 		$classes[] = 'no-active-sidebar';
 	}
 
-	if( siteorigin_setting('navigation_sticky') ) {
+	if( siteorigin_setting( 'navigation_sticky' ) ) {
 		$classes[] = 'sticky-menu';
+	}
+
+	if( ! siteorigin_setting( 'masthead_text_above' ) ) {
+		$classes[] = 'no-topbar';
 	}
 
 	return $classes;

--- a/js/north.js
+++ b/js/north.js
@@ -44,6 +44,17 @@
 			} );
 		};
 
+		// Check if an element is visible in the viewport
+		$.fn.isVisible = function() {
+			var rect = this[0].getBoundingClientRect();
+			return (
+				rect.bottom >= 0 &&
+				rect.right >= 0 &&
+				rect.top <= (window.innerHeight || document.documentElement.clientHeight) &&
+				rect.left <= (window.innerWidth || document.documentElement.clientWidth)
+			);
+		};
+
 	}
 )( jQuery );
 
@@ -210,66 +221,32 @@ jQuery( function ( $ ) {
 
 	// Now lets do the sticky menu
 
-	if ( $( '#masthead' ).hasClass( 'sticky-menu' ) && ! $( 'body' ).hasClass( 'is-mobile-device' ) ) {
+	if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
 		var $mhs = false,
 			mhTop = false,
 			pageTop = $( '#page' ).offset().top,
-			$mh = $( '#masthead' );
+			$mh = $( '#masthead' ),
+			$tb = $( '#topbar' );
 
-		var smSetup = function () {
-			pageTop = $( '#page' ).offset().top;
+		var smSetup = function() {
 
 			if ( $mhs === false ) {
 				$mhs = $( '<div class="masthead-sentinel"></div>' ).insertAfter( $mh );
 			}
-			if ( mhTop === false ) {
-				mhTop = $mh.offset().top;
+
+			if ( !$( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
+				$mhs.css( 'height', $mh.outerHeight() );
 			}
 
-
-			var top = window.pageYOffset || document.documentElement.scrollTop;
-			$mh.css( {
-				'position': $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ? 'fixed' : 'relative',
-				'top': 0,
-				'left': 0,
-				'width': null,
-			} );
-
-			var adminBarOffset = $( '#wpadminbar' ).css( 'position' ) === 'fixed' ? $( '#wpadminbar' ).outerHeight() : 0;
-
-			if ( top + adminBarOffset > $mh.offset().top ) {
-
-				$mhs.show().css( {
-					'height': $mh.outerHeight(),
-					'margin-bottom': $mh.css( 'margin-bottom' )
-				} );
-				$mh.css( {
-					'position': 'fixed',
-					'top': adminBarOffset,
-					'left': 0 - self.pageXOffset + 'px',
-					'width': '100%',
-				} );
-			}
-			else {
-				$mhs.hide();
+			if ( !$( 'body' ).hasClass( 'no-topbar' ) && !$tb.isVisible() ) {
+				$( 'body' ).addClass( 'no-topbar' );
 			}
 
-			// Don't let the height of the dropdown extend below the bottom of the screen.
-			var adminBarHeight = $( '#wpadminbar' ).css( 'position' ) === 'fixed' ? $( '#wpadminbar' ).outerHeight() : 0;
-			var mobileMenuHeight = $( window ).height() - $( '#masthead' ).innerHeight() - adminBarHeight;
-
-			if ( $('#mobile-navigation').outerHeight() > mobileMenuHeight ) {
-				$( '#mobile-navigation' ).css( {
-					'max-height': mobileMenuHeight,
-					'overflow-y': 'scroll',
-					'-webkit-overflow-scrolling' : 'touch'
-				} );
-			} else {
-				$('#mobile-navigation').css('max-height', mobileMenuHeight );
+			if ( $( 'body' ).hasClass( 'no-topbar' ) && $tb.isVisible() ) {
+				$( 'body' ).removeClass( 'no-topbar' );
 			}
-		};
+		}
 		smSetup();
-
 
 		$( window ).resize( smSetup ).scroll( smSetup );
 

--- a/js/north.js
+++ b/js/north.js
@@ -185,6 +185,28 @@ jQuery( function ( $ ) {
 				e.preventDefault();
 				$( this ).toggleClass('toggle-open').next( '.children, .sub-menu' ).slideToggle('fast');
 			} );
+
+			var mmOverflow = function() {
+				if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
+					// Don't let the height of the dropdown extend below the bottom of the screen.
+					var adminBarHeight = $( '#wpadminbar' ).css( 'position' ) === 'fixed' ? $( '#wpadminbar' ).outerHeight() : 0;
+					var mobileMenuHeight = $( window ).height() - $( '#masthead' ).innerHeight() - adminBarHeight;
+
+					if ( $('#mobile-navigation').outerHeight() > mobileMenuHeight ) {
+						$( '#mobile-navigation' ).css( {
+							'max-height': mobileMenuHeight,
+							'overflow-y': 'scroll',
+							'-webkit-overflow-scrolling' : 'touch'
+						} );
+					} else {
+						$('#mobile-navigation').css('max-height', mobileMenuHeight );
+					}
+				}
+			}
+			mmOverflow();
+
+			$( window ).resize( mmOverflow );
+
 		}
 
 		$mobileMenu.slideToggle( 'fast' );
@@ -246,19 +268,6 @@ jQuery( function ( $ ) {
 				$( 'body' ).removeClass( 'topbar-out' );
 			}
 
-			// Don't let the height of the dropdown extend below the bottom of the screen.
-			var adminBarHeight = $( '#wpadminbar' ).css( 'position' ) === 'fixed' ? $( '#wpadminbar' ).outerHeight() : 0;
-			var mobileMenuHeight = $( window ).height() - $( '#masthead' ).innerHeight() - adminBarHeight;
-
-			if ( $('#mobile-navigation').outerHeight() > mobileMenuHeight ) {
-				$( '#mobile-navigation' ).css( {
-					'max-height': mobileMenuHeight,
-					'overflow-y': 'scroll',
-					'-webkit-overflow-scrolling' : 'touch'
-				} );
-			} else {
-				$('#mobile-navigation').css('max-height', mobileMenuHeight );
-			}
 		}
 		smSetup();
 

--- a/js/north.js
+++ b/js/north.js
@@ -255,15 +255,13 @@ jQuery( function ( $ ) {
 			if ( $mhs === false ) {
 				$mhs = $( '<div class="masthead-sentinel"></div>' ).insertAfter( $mh );
 			}
-
 			if ( !$( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
 				$mhs.css( 'height', $mh.outerHeight() );
 			}
-
+			// Toggle .topbar-out with visibility of top-bar in the viewport
 			if ( !$( 'body' ).hasClass( 'no-topbar' ) && !$tb.isVisible() ) {
 				$( 'body' ).addClass( 'topbar-out' );
 			}
-
 			if ( $( 'body' ).hasClass( 'topbar-out' ) && $tb.isVisible() ) {
 				$( 'body' ).removeClass( 'topbar-out' );
 			}

--- a/js/north.js
+++ b/js/north.js
@@ -239,11 +239,25 @@ jQuery( function ( $ ) {
 			}
 
 			if ( !$( 'body' ).hasClass( 'no-topbar' ) && !$tb.isVisible() ) {
-				$( 'body' ).addClass( 'no-topbar' );
+				$( 'body' ).addClass( 'topbar-out' );
 			}
 
-			if ( $( 'body' ).hasClass( 'no-topbar' ) && $tb.isVisible() ) {
-				$( 'body' ).removeClass( 'no-topbar' );
+			if ( $( 'body' ).hasClass( 'topbar-out' ) && $tb.isVisible() ) {
+				$( 'body' ).removeClass( 'topbar-out' );
+			}
+
+			// Don't let the height of the dropdown extend below the bottom of the screen.
+			var adminBarHeight = $( '#wpadminbar' ).css( 'position' ) === 'fixed' ? $( '#wpadminbar' ).outerHeight() : 0;
+			var mobileMenuHeight = $( window ).height() - $( '#masthead' ).innerHeight() - adminBarHeight;
+
+			if ( $('#mobile-navigation').outerHeight() > mobileMenuHeight ) {
+				$( '#mobile-navigation' ).css( {
+					'max-height': mobileMenuHeight,
+					'overflow-y': 'scroll',
+					'-webkit-overflow-scrolling' : 'touch'
+				} );
+			} else {
+				$('#mobile-navigation').css('max-height', mobileMenuHeight );
 			}
 		}
 		smSetup();

--- a/js/north.js
+++ b/js/north.js
@@ -45,7 +45,7 @@
 		};
 
 		// Check if an element is visible in the viewport
-		$.fn.isVisible = function() {
+		$.fn.northIsVisible = function() {
 			var rect = this[0].getBoundingClientRect();
 			return (
 				rect.bottom >= 0 &&
@@ -289,10 +289,10 @@ jQuery( function ( $ ) {
 				$mhs.css( 'height', $mh.outerHeight() );
 			}
 			// Toggle .topbar-out with visibility of top-bar in the viewport
-			if ( !$( 'body' ).hasClass( 'no-topbar' ) && !$tb.isVisible() ) {
+			if ( !$( 'body' ).hasClass( 'no-topbar' ) && !$tb.northIsVisible() ) {
 				$( 'body' ).addClass( 'topbar-out' );
 			}
-			if ( $( 'body' ).hasClass( 'topbar-out' ) && $tb.isVisible() ) {
+			if ( $( 'body' ).hasClass( 'topbar-out' ) && $tb.northIsVisible() ) {
 				$( 'body' ).removeClass( 'topbar-out' );
 			}
 

--- a/sass/site/primary/_masthead.scss
+++ b/sass/site/primary/_masthead.scss
@@ -8,23 +8,29 @@
 	z-index: 999;
 	min-width: 1060px;
 
-	@at-root .sticky-menu.no-topbar & {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100%;
-		@include clearfix;
+	@at-root {
+		.sticky-menu.no-topbar &,
+		.sticky-menu.topbar-out & {
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100%;
+			@include clearfix;
+		}
 	}
 
-	@at-root .sticky-menu.no-topbar.admin-bar & {
-		top: 32px;
+	@at-root{
+		.sticky-menu.no-topbar.admin-bar &,
+		.sticky-menu.topbar-out.admin-bar & {
+			top: 32px;
 
-		@media screen and (max-width: 782px) {
-			top: 46px;
-		}
+			@media screen and (max-width: 782px) {
+				top: 46px;
+			}
 
-		@media screen and (max-width: 599px) {
-			top: 0;
+			@media screen and (max-width: 599px) {
+				top: 0;
+			}
 		}
 	}
 

--- a/sass/site/primary/_masthead.scss
+++ b/sass/site/primary/_masthead.scss
@@ -9,6 +9,10 @@
 	min-width: 1060px;
 
 	@at-root {
+		.sticky-menu:not(.no-topbar) & {
+			position: absolute;
+		}
+
 		.sticky-menu.no-topbar &,
 		.sticky-menu.topbar-out & {
 			position: fixed;
@@ -17,9 +21,7 @@
 			width: 100%;
 			@include clearfix;
 		}
-	}
 
-	@at-root{
 		.sticky-menu.no-topbar.admin-bar &,
 		.sticky-menu.topbar-out.admin-bar & {
 			top: 32px;

--- a/sass/site/primary/_masthead.scss
+++ b/sass/site/primary/_masthead.scss
@@ -8,6 +8,26 @@
 	z-index: 999;
 	min-width: 1060px;
 
+	@at-root .sticky-menu.no-topbar & {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		@include clearfix;
+	}
+
+	@at-root .sticky-menu.no-topbar.admin-bar & {
+		top: 32px;
+
+		@media screen and (max-width: 782px) {
+			top: 46px;
+		}
+
+		@media screen and (max-width: 599px) {
+			top: 0;
+		}
+	}
+
 	.container-inner {
 		display: table;
 		width: 100%;
@@ -99,6 +119,8 @@
 	min-width: 1060px;
 	background: $masthead__top_background_color;
 	border-bottom: $masthead__border_width solid $masthead__border_color;
+	position: relative;
+	z-index: 1000;
 
 	p {
 		text-align: right;

--- a/style.css
+++ b/style.css
@@ -1251,6 +1251,21 @@ a {
   width: 100%;
   z-index: 999;
   min-width: 1060px; }
+  .sticky-menu.no-topbar #masthead {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    content: "";
+    display: table; }
+  .sticky-menu.no-topbar.admin-bar #masthead {
+    top: 32px; }
+    @media screen and (max-width: 782px) {
+      .sticky-menu.no-topbar.admin-bar #masthead {
+        top: 46px; } }
+    @media screen and (max-width: 599px) {
+      .sticky-menu.no-topbar.admin-bar #masthead {
+        top: 0; } }
   #masthead .container-inner {
     display: table;
     width: 100%; }
@@ -1312,7 +1327,9 @@ a {
   width: 100%;
   min-width: 1060px;
   background: #f4f4f4;
-  border-bottom: 1px solid #d4d4d4; }
+  border-bottom: 1px solid #d4d4d4;
+  position: relative;
+  z-index: 1000; }
   #topbar p {
     text-align: right;
     line-height: 3em;

--- a/style.css
+++ b/style.css
@@ -1251,6 +1251,8 @@ a {
   width: 100%;
   z-index: 999;
   min-width: 1060px; }
+  .sticky-menu:not(.no-topbar) #masthead {
+    position: absolute; }
   .sticky-menu.no-topbar #masthead,
   .sticky-menu.topbar-out #masthead {
     position: fixed;

--- a/style.css
+++ b/style.css
@@ -1251,20 +1251,24 @@ a {
   width: 100%;
   z-index: 999;
   min-width: 1060px; }
-  .sticky-menu.no-topbar #masthead {
+  .sticky-menu.no-topbar #masthead,
+  .sticky-menu.topbar-out #masthead {
     position: fixed;
     top: 0;
     left: 0;
     width: 100%;
     content: "";
     display: table; }
-  .sticky-menu.no-topbar.admin-bar #masthead {
+  .sticky-menu.no-topbar.admin-bar #masthead,
+  .sticky-menu.topbar-out.admin-bar #masthead {
     top: 32px; }
     @media screen and (max-width: 782px) {
-      .sticky-menu.no-topbar.admin-bar #masthead {
+      .sticky-menu.no-topbar.admin-bar #masthead,
+      .sticky-menu.topbar-out.admin-bar #masthead {
         top: 46px; } }
     @media screen and (max-width: 599px) {
-      .sticky-menu.no-topbar.admin-bar #masthead {
+      .sticky-menu.no-topbar.admin-bar #masthead,
+      .sticky-menu.topbar-out.admin-bar #masthead {
         top: 0; } }
   #masthead .container-inner {
     display: table;


### PR DESCRIPTION
@gregpriday I made a few changes to be less reliant on JavaScript.

When the `#topbar` is not used, the sticky navigation works smoothly across all devices & browsers*.

When the `#topbar` is used, the sticky navigation will not work on iOS on the initial touch and swipe**. After which it works smoothly.

\* I tested it on Chrome, Firefox, Safari, iOS Safari(Simulator) and Android.
** iOS devices freeze DOM manipulation during scroll, queuing up JS to apply when the scroll finishes.

If you like it, @Misplon could further test it before merging. :)