### PR TITLE
Fixed blog page title

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@ get_header(); ?>
 
 			<?php if ( siteorigin_page_setting( 'page_title' ) ) : ?>
 				<header>
-					<?php if( single_post_title() ) : ?>
+					<?php if( single_post_title( '', false ) ) : ?>
 						<h1 class="page-title"><?php single_post_title(); ?></h1>
 					<?php else : ?>
 						<h1 class="page-title">


### PR DESCRIPTION
Fixed bug #163 

the `single_post_title` function was displaying instead of returning page title.