### PR TITLE
Author box

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -111,6 +111,11 @@ if ( version_compare( $GLOBALS['wp_version'], '4.1', '<' ) ) :
 	add_action( 'wp_head', 'siteorigin_north_render_title' );
 endif;
 
+/*
+ * Allow the use of HTML in author bio
+ */
+remove_filter( 'pre_user_description' , 'wp_filter_kses' );
+
 if ( ! function_exists( 'siteorigin_north_tag_cloud_widget' ) ) :
 /*
  * Have a uniform size for the tag cloud items

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -183,6 +183,7 @@ function siteorigin_north_entry_footer() {
 				</h2>
 				<div class="author-avatar">
 					<?php echo get_avatar( get_the_author_meta( 'ID' ), 100 ); ?>
+					<?php do_action( 'siteorigin_north_after_entry_author_avatar' ); ?>
 				</div>
 				<div class="author-description">
 					<?php echo wp_kses( get_the_author_meta( 'description' ), null ); ?>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -171,21 +171,21 @@ function siteorigin_north_entry_footer() {
 
 		if ( siteorigin_setting('blog_display_author_box') ) { ?>
 			<div class="author-box">
-				<h2 class="author-title">
-					<?php echo ( (!is_rtl()) ? get_the_author() : ''); ?>
-					<small class="author-info">
-						<a href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>">
-							<?php _e( 'View posts by ', 'siteorigin-north' );
-							echo get_the_author(); ?>
-						</a>
-					</small>
-					<?php echo ( (is_rtl()) ? get_the_author() : ''); ?>
-				</h2>
 				<div class="author-avatar">
 					<?php echo get_avatar( get_the_author_meta( 'ID' ), 100 ); ?>
 					<?php do_action( 'siteorigin_north_after_entry_author_avatar' ); ?>
 				</div>
 				<div class="author-description">
+					<h2 class="author-title">
+						<?php echo ( (!is_rtl()) ? get_the_author() : ''); ?>
+						<small class="author-info">
+							<a href="<?php echo get_author_posts_url( get_the_author_meta( 'ID' ) ); ?>">
+								<?php _e( 'View posts by ', 'siteorigin-north' );
+								echo get_the_author(); ?>
+							</a>
+						</small>
+						<?php echo ( (is_rtl()) ? get_the_author() : ''); ?>
+					</h2>
 					<?php echo wp_kses_post( get_the_author_meta( 'description' ), null ); ?>
 				</div>
 				<div class="clear"></div>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -186,7 +186,7 @@ function siteorigin_north_entry_footer() {
 					<?php do_action( 'siteorigin_north_after_entry_author_avatar' ); ?>
 				</div>
 				<div class="author-description">
-					<?php echo wp_kses( get_the_author_meta( 'description' ), null ); ?>
+					<?php echo wp_kses_post( get_the_author_meta( 'description' ), null ); ?>
 				</div>
 				<div class="clear"></div>
 			</div>

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -223,10 +223,17 @@
 
 	.author-title {
 		margin-top: 0;
+		line-height: 1;
+		font-size: 1.25em;
 
 		.author-info {
 			font-size: 0.6em;
 			padding: 0 5px;
+			font-weight: bold;
+
+			a {
+				text-decoration: none;
+			}
 		}
 	}
 

--- a/sass/site/primary/_posts-and-pages.scss
+++ b/sass/site/primary/_posts-and-pages.scss
@@ -218,8 +218,8 @@
 
 .author-box {
 	margin: 20px 0;
-	padding: 10px;
-	border: 1px solid $color__border-table;
+	padding: 20px;
+	background: rgba(0,0,0,0.05);
 
 	.author-title {
 		margin-top: 0;

--- a/style.css
+++ b/style.css
@@ -1657,8 +1657,8 @@ a {
 
 .author-box {
   margin: 20px 0;
-  padding: 10px;
-  border: 1px solid #c9c9c9; }
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.05); }
   .author-box .author-title {
     margin-top: 0; }
     .author-box .author-title .author-info {

--- a/style.css
+++ b/style.css
@@ -1660,10 +1660,15 @@ a {
   padding: 20px;
   background: rgba(0, 0, 0, 0.05); }
   .author-box .author-title {
-    margin-top: 0; }
+    margin-top: 0;
+    line-height: 1;
+    font-size: 1.25em; }
     .author-box .author-title .author-info {
       font-size: 0.6em;
-      padding: 0 5px; }
+      padding: 0 5px;
+      font-weight: bold; }
+      .author-box .author-title .author-info a {
+        text-decoration: none; }
   .author-box .author-avatar {
     float: left; }
   .author-box .author-description {


### PR DESCRIPTION
Implemented enhancement #186, #185 and #184

You can now use HTML in the author box. So for paragraphs you will need to use the paragraph `<p>` elements.

Added the action hook `siteorigin_north_after_entry_author_avatar` after the author avatar.

**Styling updates:**
removed border.
added `background: rgba(0,0,0,0.05)`. The alpha value of  0.05 should make the box compatible with different body background colors.
increased the padding on the author box slightly.
