### PR TITLE
fix to ignore LiveMesh tabs for smooth scrolling

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -392,7 +392,7 @@ jQuery( function ( $ ) {
 
 	// Handle smooth scrolling
 	if ( siteoriginNorth.smoothScroll ) {
-		$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).northSmoothScroll();
+		$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).not( '.lsow-tab a[href*="#"]:not([href="#"])' ).northSmoothScroll();
 	}
 
 	// Add class to calendar elements that have links


### PR DESCRIPTION
Temporary fix for #200 

