### PR TITLE
Correct warning notice with menu breakpoint css

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -933,7 +933,7 @@ if ( ! function_exists( 'siteorigin_north_menu_breakpoint_css' ) ) :
  * Add CSS for mobile menu breakpoint
  */
 function siteorigin_north_menu_breakpoint_css( $css, $settings ) {
-	if( $settings[ 'theme_settings_responsive_menu_breakpoint' ] != null ) {
+	if( isset( $settings[ 'theme_settings_responsive_menu_breakpoint' ] ) && !empty( $settings[ 'theme_settings_responsive_menu_breakpoint' ] ) ) {
 
 		$breakpoint = $settings[ 'theme_settings_responsive_menu_breakpoint' ];
 


### PR DESCRIPTION
If theme_settings_responsive_menu_breakpoint is never changed, theme_settings_responsive_menu_breakpoint won't actually be set as the default is used in that instance.

As such, the null check will produce a warning notice if WP_DEBUG is enabled and the setting hasn't been changed.