### PR TITLE
Added infinite scroll styling and template for woocommerce

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -26,9 +26,18 @@ if ( ! function_exists( 'siteorigin_north_infinite_scroll_render' ) ) :
  * Custom render function for Infinite Scroll.
  */
 function siteorigin_north_infinite_scroll_render() {
-	while ( have_posts() ) {
-		the_post();
-		get_template_part( 'template-parts/content', get_post_format() );
+	if ( function_exists( 'is_woocommerce' ) && ( is_shop() || is_woocommerce() ) ) {
+		echo '<ul class="products">';
+		while ( have_posts() ) {
+			the_post();
+			wc_get_template_part( 'content', 'product' );
+		}
+		echo '</ul>';
+	} else {
+		while ( have_posts() ) {
+			the_post();
+			get_template_part( 'template-parts/content', get_post_format() );
+		}
 	}
 } // end function siteorigin_north_infinite_scroll_render
 endif;

--- a/sass/modules/_infinite-scroll.scss
+++ b/sass/modules/_infinite-scroll.scss
@@ -1,5 +1,6 @@
 /* Globally hidden elements when Infinite Scroll is supported and in use. */
-.infinite-scroll .posts-navigation, /* Older / Newer Posts Navigation (always hidden) */
+.infinite-scroll .post-pagination, /* Older / Newer Posts Navigation (always hidden) */
+.infinite-scroll .woocommerce-result-count,
 .infinite-scroll.neverending .site-footer { /* Theme Footer (when set to scrolling) */
 	display: none;
 }

--- a/style.css
+++ b/style.css
@@ -1836,7 +1836,8 @@ a {
 # Infinite scroll
 --------------------------------------------------------------*/
 /* Globally hidden elements when Infinite Scroll is supported and in use. */
-.infinite-scroll .posts-navigation,
+.infinite-scroll .post-pagination,
+.infinite-scroll .woocommerce-result-count,
 .infinite-scroll.neverending .site-footer {
   /* Theme Footer (when set to scrolling) */
   display: none; }


### PR DESCRIPTION
Fixed bug #230 

Added styling for infinite scrolling.
Hiding product count when infinite scroll is active.
Displays the WC archive product template for WC archives.

@Misplon please test. May have bugs. Thanks.