### PR TITLE
Initial Load Smooth Scroll - account for page load

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -388,9 +388,10 @@ jQuery( function ( $ ) {
 
 	// Handle smooth scrolling
 	if ( siteoriginNorth.smoothScroll ) {
-		$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).not( '.lsow-tab a[href*="#"]:not([href="#"]), .wc-tabs a[href*="#"]:not([href="#"]), .iw-so-tab-title a[href*="#"]:not([href="#"])' ).northSmoothScroll();
+		setTimeout(function() {
+			$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).not( '.lsow-tab a[href*="#"]:not([href="#"]), .wc-tabs a[href*="#"]:not([href="#"]), .iw-so-tab-title a[href*="#"]:not([href="#"])' ).northSmoothScroll();
+		}, 1000);
 	}
-
 	// Add class to calendar elements that have links
 	$( '#wp-calendar tbody td:has(a)' ).addClass( 'has-link' );
 


### PR DESCRIPTION
When widgets like the SiteOrigin Hero widget are present on the page and a user has navigated to this page via a link with a fragment (example.com/example-page/#test), chances are the user will end up in the wrong location due to the hero widget setup not being complete. This will avoid that issue. Another option might be to do the initial one, and then another check a second later but that is likely overkill.