### PR TITLE
Logo and title

### DIFF
--- a/inc/settings.conf.php
+++ b/inc/settings.conf.php
@@ -23,6 +23,7 @@ return array(
 		'fonts_text_meta' => 'color__text_meta',
 		'fonts_text_menu' => 'color__text_menu',
 		'fonts_text_menu_hover' => 'color__text_menu_hover',
+		'fonts_text_menu_current' => 'color__text_menu_current',
 
 		// The header customizations
 		'masthead_background_color' => 'masthead__background_color',

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -21,6 +21,11 @@ function siteorigin_north_settings_init(){
 					'label'       => __( 'Retina Logo', 'siteorigin-north' ),
 					'description' => __( 'A double sized logo to use on retina devices.', 'siteorigin-north' )
 				),
+				'site_title' => array(
+					'type'        => 'checkbox',
+					'label'       => __( 'Site Title', 'siteorigin-north' ),
+					'description' => __( 'Show your site title alongside your logo.', 'siteorigin-north' )
+				),
 				'site_description' => array(
 					'type'        => 'checkbox',
 					'label'       => __( 'Site Description', 'siteorigin-north' ),
@@ -1047,6 +1052,7 @@ function siteorigin_north_settings_defaults( $defaults ){
 	// Branding defaults
 	$defaults['branding_logo']             = false;
 	$defaults['branding_logo_retina']      = false;
+	$defaults['branding_site_title']       = false;
 	$defaults['branding_site_description'] = true;
 	$defaults['branding_attribution']      = false;
 	$defaults['branding_accent']           = '#c75d5d';

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -552,7 +552,7 @@ function siteorigin_north_settings_custom_css($css){
 	color: ${fonts_text_menu_hover};
 	}
 	.main-navigation .menu > li.current-menu-item > a,.main-navigation .menu > li.current-menu-ancestor > a {
-	color: ${fonts_text_menu_hover};
+	color: ${fonts_text_menu_current};
 	}
 	.main-navigation #mobile-menu-button {
 	color: ${responsive_mobile_text_color};

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -79,24 +79,28 @@ function siteorigin_north_settings_init(){
 				// The colors
 
 				'text_dark'   => array(
-					'type'  => 'color',
-					'label' => __( 'Dark Text Color', 'siteorigin-north' ),
-					'live'  => true,
+					'type'        => 'color',
+					'label'       => __( 'Dark Text Color', 'siteorigin-north' ),
+					'description' => __( 'Applied to headings and titles.', 'siteorigin-north' ),
+					'live'        => true,
 				),
 				'text_medium' => array(
-					'type'  => 'color',
-					'label' => __( 'Medium Text Color', 'siteorigin-north' ),
-					'live'  => true,
+					'type'        => 'color',
+					'label'       => __( 'Medium Text Color', 'siteorigin-north' ),
+					'description' => __( 'Default color applied to all text.', 'siteorigin-north' ),
+					'live'        => true,
 				),
 				'text_light'  => array(
-					'type'  => 'color',
-					'label' => __( 'Light Text Color', 'siteorigin-north' ),
-					'live'  => true,
+					'type'        => 'color',
+					'label'       => __( 'Light Text Color', 'siteorigin-north' ),
+					'description' => __( 'Applied to comments and breadcrumbs.', 'siteorigin-north' ),
+					'live'        => true,
 				),
 				'text_meta'   => array(
-					'type'  => 'color',
-					'label' => __( 'Meta Text Color', 'siteorigin-north' ),
-					'live'  => true,
+					'type'        => 'color',
+					'label'       => __( 'Meta Text Color', 'siteorigin-north' ),
+					'description' => __( 'Applied to bylines.', 'siteorigin-north' ),
+					'live'        => true,
 				),
 				'text_menu'   => array(
 					'type'  => 'color',
@@ -112,7 +116,7 @@ function siteorigin_north_settings_init(){
 					'type'  => 'color',
 					'label' => __( 'Menu Text Current Color', 'siteorigin-north' ),
 					'live'  => true,
-				),				
+				),
 
 			),
 		),

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -7,13 +7,13 @@
  * @package siteorigin-north
  */
 
-if( !function_exists('siteorigin_north_display_logo') ):
+if ( ! function_exists( 'siteorigin_north_display_logo' ) ):
 /**
  * Display the logo or site title
  */
-function siteorigin_north_display_logo(){
+function siteorigin_north_display_logo() {
 	$logo = siteorigin_setting( 'branding_logo' );
-	if( !empty($logo) ) {
+	if ( ! empty( $logo ) ) {
 		$attrs = apply_filters( 'siteorigin_north_logo_attributes', array() );
 
 		?><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
@@ -23,18 +23,25 @@ function siteorigin_north_display_logo(){
 
 	} elseif ( function_exists( 'has_custom_logo' ) && has_custom_logo() ) {
 		?><?php the_custom_logo(); ?><?php
-	}
-	else {
+	} else {
 		if ( is_front_page() ) : ?>
 			<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 		<?php else : ?>
 			<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
 		<?php endif;
 	}
+
+	if ( ( $logo || ( function_exists( 'has_custom_logo' ) && has_custom_logo() ) ) && siteorigin_setting( 'branding_site_title' ) ) {
+		if ( is_front_page() ) : ?>
+			<h1 class="logo-site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+		<?php else : ?>
+			<p class="logo-site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+		<?php endif;
+	}
 }
 endif;
 
-if( !function_exists('siteorigin_north_display_retina_logo') ):
+if ( ! function_exists( 'siteorigin_north_display_retina_logo' ) ):
 /**
  * Display a retina ready logo
  */
@@ -42,18 +49,18 @@ function siteorigin_north_display_retina_logo( $attr ){
 	$logo = siteorigin_setting( 'branding_logo' );
 	$retina = siteorigin_setting( 'branding_retina_logo' );
 
-	if( !empty($retina) ) {
+	if( ! empty( $retina ) ) {
 
 		$srcset = array();
 
 		$logo_src = wp_get_attachment_image_src( $logo, 'full' );
 		$retina_src = wp_get_attachment_image_src( $retina, 'full' );
 
-		if( !empty( $logo_src ) ) {
+		if( ! empty( $logo_src ) ) {
 			$srcset[] = $logo_src[0] . ' 1x';
 		}
 
-		if( !empty( $logo_src ) ) {
+		if( ! empty( $logo_src ) ) {
 			$srcset[] = $retina_src[0] . ' 2x';
 		}
 

--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -21,13 +21,13 @@
 			a {
 				padding-left: 30px;
 				padding-right: 30px;
-				
+
 				&.stripped-backlink {
 					font-weight: bold;
-					font-weight: 600; 
+					font-weight: 600;
 					padding-left: 0;
 					padding-right: 0;
-				}				
+				}
 			}
 		}
 
@@ -132,7 +132,7 @@
 			&.current-menu-item,
 			&.current-menu-ancestor {
 				> a {
-					color: $navigation__link_hover_color;
+					color: $navigation__link_current_color;
 				}
 			}
 		}

--- a/sass/site/primary/_masthead.scss
+++ b/sass/site/primary/_masthead.scss
@@ -58,7 +58,8 @@
 			}
 		}
 
-		.site-title {
+		.site-title,
+		.logo-site-title {
 			margin: 0;
 			color: $color__text_dark;
 			font-family: $font__headings;
@@ -72,14 +73,20 @@
 			}
 		}
 
+		.logo-site-title {
+			display: inline-block;
+			vertical-align: bottom;
+		}
+
 		.site-description {
 			margin: 0.25em 0 0 0;
 			font-size: 0.9em;
 		}
 
 		img {
-			display: block;
+			display: inline-block;
 			max-width: 100%;
+			vertical-align: middle;
 		}
 	}
 

--- a/sass/variables-site/_variables-site.scss
+++ b/sass/variables-site/_variables-site.scss
@@ -27,7 +27,8 @@ $color__text_medium: #595959;
 $color__text_light: #898989;
 $color__text_meta: #b0b0b0;
 $color__text_menu: #898989;
-$color__text_menu_hover: #292929;
+$color__text_menu_hover: #595959;
+$color__text_menu_current: #292929;
 
 // Masthead
 $masthead__background_color: #fafafa;
@@ -40,6 +41,7 @@ $masthead__bottom_margin: 30px;
 // Navigation colors
 $navigation__link_color: $color__text_menu;
 $navigation__link_hover_color: $color__text_menu_hover;
+$navigation__link_current_color: $color__text_menu_current;
 $navigation__dropdown_background_color: $masthead__background_color;
 $navigation__dropdown_border_color: $masthead__border_color;
 

--- a/style.css
+++ b/style.css
@@ -521,7 +521,7 @@ a {
     .main-navigation ul a {
       color: #898989; }
       .main-navigation ul a:hover {
-        color: #292929; }
+        color: #595959; }
     .main-navigation ul ul {
       position: absolute;
       top: 100%;
@@ -573,10 +573,10 @@ a {
         padding-bottom: 1.25em; }
       .main-navigation ul ul :hover > a,
       .main-navigation ul ul .focus > a {
-        color: #292929; }
+        color: #595959; }
       .main-navigation ul ul a:hover,
       .main-navigation ul ul a.focus {
-        color: #292929; }
+        color: #595959; }
     body.no-touch .main-navigation ul li:hover > ul,
     body.no-touch .main-navigation ul li.focus > ul {
       opacity: 1;
@@ -631,9 +631,9 @@ a {
     .main-navigation #mobile-menu-button .svg-icon-menu path {
       fill: #777; }
     .main-navigation #mobile-menu-button:hover {
-      color: #292929; }
+      color: #595959; }
       .main-navigation #mobile-menu-button:hover .svg-icon-menu path {
-        fill: #292929; }
+        fill: #595959; }
     .main-navigation #mobile-menu-button.to-close .line-1 {
       -webkit-transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px);
       -moz-transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px);
@@ -665,7 +665,7 @@ a {
       .main-navigation .north-search-icon .svg-icon-search path {
         fill: #898989; }
       .main-navigation .north-search-icon .svg-icon-search:hover path {
-        fill: #292929; }
+        fill: #595959; }
 
 #header-search {
   display: none;
@@ -742,7 +742,7 @@ a {
 .main-navigation.stripped a {
   color: #898989; }
   .main-navigation.stripped a:hover {
-    color: #292929; }
+    color: #595959; }
 
 #mobile-navigation {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -1297,22 +1297,28 @@ a {
         -ms-transform-origin: center center;
         -o-transform-origin: center center;
         transform-origin: center center; }
-    #masthead .site-branding .site-title {
+    #masthead .site-branding .site-title,
+    #masthead .site-branding .logo-site-title {
       margin: 0;
       color: #292929;
       font-family: "Montserrat", sans-serif;
       font-size: 1.5em;
       line-height: 1.2em;
       white-space: nowrap; }
-      #masthead .site-branding .site-title a {
+      #masthead .site-branding .site-title a,
+      #masthead .site-branding .logo-site-title a {
         text-decoration: none;
         color: inherit; }
+    #masthead .site-branding .logo-site-title {
+      display: inline-block;
+      vertical-align: bottom; }
     #masthead .site-branding .site-description {
       margin: 0.25em 0 0 0;
       font-size: 0.9em; }
     #masthead .site-branding img {
-      display: block;
-      max-width: 100%; }
+      display: inline-block;
+      max-width: 100%;
+      vertical-align: middle; }
   #masthead .site-branding, #masthead .main-navigation {
     display: table-cell;
     vertical-align: middle; }


### PR DESCRIPTION
Implemented enhancements #251 #255 

- Added description to text color settings as discussed.
- The Current menu item color had not been implemented. Fixed it. Please check.
- Added setting to display site title alongside the logo. Added it under branding.
- The setting adds the title only if a logo is present.
- The logo scaling still works. No scaling has been done to the title and description.

A preview:
![screenshot-so dev 2017-01-26 16-06-50](https://cloud.githubusercontent.com/assets/3372029/22328299/7e9f805e-e3e1-11e6-8a5e-29cbc5cc5acd.png)

Let me know if any changes are needed. Thanks
