### PR TITLE
Added option to change number of WC archive columns

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -59,6 +59,10 @@ function siteorigin_north_body_classes( $classes ) {
 		$classes[] = 'mobile-scroll-to-top';
 	}
 
+	if ( siteorigin_setting( 'woocommerce_archive_columns' ) ) {
+		$classes[] = 'wc-columns-' . siteorigin_setting( 'woocommerce_archive_columns' );
+	}
+
 	return $classes;
 }
 endif;

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -422,6 +422,14 @@ function siteorigin_north_woocommerce_settings( $settings ) {
 			'title'  => __( 'WooCommerce', 'siteorigin-north' ),
 			'fields' => array(
 
+				'archive_columns' => array(
+					'type' => 'range',
+					'label' => esc_html__( 'Number of columns on archive pages.', 'siteorigin-north' ),
+					'min' => 2,
+					'max' => 5,
+					'step' => 1
+				),
+
 				'display_cart' => array(
 					'type'        => 'checkbox',
 					'label'       => __( 'Display Cart', 'siteorigin-north' ),
@@ -1170,6 +1178,7 @@ function siteorigin_north_settings_defaults( $defaults ){
 	$defaults['footer_top_margin']       = '30px';
 
 	// WooCommerce defaults
+	$defaults['woocommerce_archive_columns']       = 3;
 	$defaults['woocommerce_display_cart']          = true;
 	$defaults['woocommerce_display_checkout_cart'] = false;
 	$defaults['woocommerce_display_quick_view']    = false;

--- a/sass/woocommerce/_archives.scss
+++ b/sass/woocommerce/_archives.scss
@@ -105,9 +105,27 @@
 	#main {
 		ul.products {
 			li.product {
-				margin: 0 3.8% 2.992em 0;
-				width: 30.8%;
 				text-align: center;
+
+				@at-root .wc-columns-2#{&} {
+					margin: 0 5% 2.992em 0;
+					width: 47.5%;
+				}
+
+				@at-root .wc-columns-3#{&} {
+					margin: 0 3.8% 2.992em 0;
+					width: 30.8%;
+				}
+
+				@at-root .wc-columns-4#{&} {
+					margin: 0 3.333% 2.992em 0;
+					width: 22.5%;
+				}
+
+				@at-root .wc-columns-5#{&} {
+					margin: 0 2.9% 2.992em 0;
+					width: 17.68%;
+				}
 
 				@media (max-width: 768px) {
 					@at-root body.responsive#{&} {
@@ -117,7 +135,7 @@
 				}
 
 				a.added_to_cart {
-					font-size: 13px; 
+					font-size: 13px;
 				}
 
 				&.last {

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -99,9 +99,19 @@
   padding-top: 8px; }
 
 .woocommerce #main ul.products li.product {
-  margin: 0 3.8% 2.992em 0;
-  width: 30.8%;
   text-align: center; }
+  .wc-columns-2.woocommerce #main ul.products li.product {
+    margin: 0 5% 2.992em 0;
+    width: 47.5%; }
+  .wc-columns-3.woocommerce #main ul.products li.product {
+    margin: 0 3.8% 2.992em 0;
+    width: 30.8%; }
+  .wc-columns-4.woocommerce #main ul.products li.product {
+    margin: 0 3.333% 2.992em 0;
+    width: 22.5%; }
+  .wc-columns-5.woocommerce #main ul.products li.product {
+    margin: 0 2.9% 2.992em 0;
+    width: 17.68%; }
   @media (max-width: 768px) {
     body.responsive.woocommerce #main ul.products li.product {
       width: 48%;

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -234,3 +234,11 @@ function siteorigin_north_paypal_icon() {
 }
 add_filter( 'woocommerce_paypal_icon', 'siteorigin_north_paypal_icon' );
 endif;
+
+if ( ! function_exists( 'siteorigin_north_wc_columns' ) ) :
+// Change number of products per row
+function siteorigin_north_wc_columns() {
+	return siteorigin_setting( 'woocommerce_archive_columns' );
+}
+endif;
+add_filter( 'loop_shop_columns', 'siteorigin_north_wc_columns' );


### PR DESCRIPTION
enhancement #272 

- Added setting to change number of WC columns. Users can choose from 2-5 (default 3).
- Add body class for number of WC columns.
- Added function to change column number https://docs.woocommerce.com/document/change-number-of-products-per-row/#section-1
- Added CSS for the different column numbers