### PR TITLE
Added vendor-prefixed properties to animate hamburger icon

### DIFF
--- a/sass/navigation/_menus.scss
+++ b/sass/navigation/_menus.scss
@@ -204,34 +204,34 @@
 			$translate_dist: 8.75px;
 
 			.line-1 {
-				transform: rotate(-45deg) translateY($translate_dist) translateX(-$translate_dist);
+				@include transform( rotate(-45deg) translateY($translate_dist) translateX(-$translate_dist) );
 			}
 
 			.line-2 {
 				opacity: 0;
-				transform: translateX($translate_dist * 1.25);
+				@include transform( translateX($translate_dist * 1.25) );
 			}
 
 			.line-3 {
-				transform: rotate(45deg) translateY(-$translate_dist - 2px) translateX(-$translate_dist);
+				@include transform( rotate(45deg) translateY(-$translate_dist - 2px) translateX(-$translate_dist) );
 			}
 		}
 	}
 
 	// Search icon.
 	.north-search-icon {
-		border: none; 
+		border: none;
 		box-shadow: none;
 		color: inherit;
 		cursor: pointer;
 		display: inline-block;
-		line-height: normal; 
+		line-height: normal;
 		padding: 0;
 		position: relative;
 		top: 2px;
-		
+
 		&:hover {
-			background: none; 
+			background: none;
 		}
 
 		.svg-icon-search {
@@ -253,7 +253,7 @@
 		display: inline-block;
 
 		.mega-sub-menu {
-			
+
 			li {
 				min-width: auto;
 			}
@@ -275,8 +275,8 @@
 	top: 0;
 	width: 100%;
 	z-index: 99999;
-	
-	.container, 
+
+	.container,
 	.search-form {
 		height: 100%;
 	}

--- a/style.css
+++ b/style.css
@@ -634,11 +634,23 @@ a {
       .main-navigation #mobile-menu-button:hover .svg-icon-menu path {
         fill: #595959; }
     .main-navigation #mobile-menu-button.to-close .line-1 {
+      -webkit-transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px);
+      -moz-transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px);
+      -ms-transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px);
+      -o-transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px);
       transform: rotate(-45deg) translateY(8.75px) translateX(-8.75px); }
     .main-navigation #mobile-menu-button.to-close .line-2 {
       opacity: 0;
+      -webkit-transform: translateX(10.9375px);
+      -moz-transform: translateX(10.9375px);
+      -ms-transform: translateX(10.9375px);
+      -o-transform: translateX(10.9375px);
       transform: translateX(10.9375px); }
     .main-navigation #mobile-menu-button.to-close .line-3 {
+      -webkit-transform: rotate(45deg) translateY(-10.75px) translateX(-8.75px);
+      -moz-transform: rotate(45deg) translateY(-10.75px) translateX(-8.75px);
+      -ms-transform: rotate(45deg) translateY(-10.75px) translateX(-8.75px);
+      -o-transform: rotate(45deg) translateY(-10.75px) translateX(-8.75px);
       transform: rotate(45deg) translateY(-10.75px) translateX(-8.75px); }
   .main-navigation .north-search-icon {
     border: none;


### PR DESCRIPTION
Fixed bug #307 

Read that older versions of iOS Safari needs vendor prefixed properties for transition, translate, etc.. 