### PR TITLE
Comments: Add moderation notice

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -322,6 +322,11 @@ function siteorigin_north_comment( $comment, $args, $depth ) {
 			</div>
 
 			<div class="comment-content content">
+				<?php if( ! $comment->comment_approved ) : ?>
+					<p class="comment-awaiting-moderation">
+						<?php _e( 'Your comment is awaiting moderation.', 'siteorigin-north' ); ?>
+					</p>
+				<?php endif; ?>
 				<?php comment_text(); ?>
 			</div>
 		</div>

--- a/sass/site/primary/_comments.scss
+++ b/sass/site/primary/_comments.scss
@@ -19,6 +19,10 @@
 
 		.comment-container {
 			margin-left: 120px;
+			
+			.comment-awaiting-moderation {
+				font-style: italic;
+			}
 		}
 
 		&.pingback {

--- a/style.css
+++ b/style.css
@@ -1948,6 +1948,8 @@ article.page {
     width: auto; }
     .comment-list li.comment .comment-container {
       margin-left: 120px; }
+      .comment-list li.comment .comment-container .comment-awaiting-moderation {
+        font-style: italic; }
     .comment-list li.comment.pingback .comment-container {
       margin-left: 0; }
     .comment-list li.comment .avatar-container {


### PR DESCRIPTION
The comment callback in North isn't very clear if your comment is in moderation or not. This PR will correct that.

([Slack Reference](https://siteorigin.slack.com/archives/C02T5GSNA/p1508976761000083))