### PR TITLE
Update WC Cart URL in header.php

### DIFF
--- a/header.php
+++ b/header.php
@@ -107,7 +107,7 @@
 									<?php global $woocommerce; ?>
 									<ul class="shopping-cart">
 										<li>
-											<a class="shopping-cart-link" href="<?php echo $woocommerce->cart->get_cart_url();?>">
+											<a class="shopping-cart-link" href="<?php echo esc_url( wc_get_cart_url() ); ?>">
 												<span class="screen-reader-text"><?php esc_html_e( 'View shopping cart', 'siteorigin-north' ); ?></span>
 												<span class="north-icon-cart"></span>
 												<span class="shopping-cart-text"><?php esc_html_e( ' View Cart ', 'siteorigin-north' ); ?></span>


### PR DESCRIPTION
Fixes WC notice:

> Notice: WC_Cart::get_cart_url is deprecated since version 2.5! Use wc_get_cart_url instead

![](https://i.imgur.com/7Us16SF.png)