### PR TITLE
Logo Scaling: Add filter to adjust scale and prevent constant rescaling

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -261,9 +261,11 @@ function siteorigin_north_scripts() {
 	// Skip link focus fix.
 	wp_enqueue_script( 'siteorigin-north-skip-link', get_template_directory_uri() . '/js/skip-link-focus-fix' . SITEORIGIN_THEME_JS_PREFIX . '.js', array(), SITEORIGIN_THEME_VERSION, true );
 
-	// Localize smooth scroll.
+	// Localize smooth scroll and output sticky logo scale
+	$logo_sticky_scale = apply_filters( 'siteorigin_north_logo_sticky_scale', 0.755 );
 	wp_localize_script( 'siteorigin-north-script', 'siteoriginNorth', array(
-		'smoothScroll' => siteorigin_setting( 'navigation_smooth_scroll' )
+		'smoothScroll' => siteorigin_setting( 'navigation_smooth_scroll' ),
+		'logoScale' => is_numeric( $logo_sticky_scale ) ? $logo_sticky_scale : 0.755,
 	) );
 
 	// jQuery FitVids.

--- a/js/north.js
+++ b/js/north.js
@@ -71,7 +71,7 @@
 						if ( $target.offset().top < 48 ) {
 							height += $( '#masthead' ).outerHeight();
 						} else if ( $( '.site-branding' ).outerHeight() > $( '#site-navigation' ).outerHeight() ) {
-							height += $( '#masthead' ).outerHeight() * 0.775;
+							height += $( '#masthead' ).outerHeight() * siteoriginNorth.logoScale;
 						} else {
 							height += $( '#masthead' ).height() + ( $( '#masthead' ).innerHeight() - $( '#masthead' ).height() );
 						}
@@ -367,36 +367,35 @@ jQuery( function ( $ ) {
 		};
 
 		if ( $mh.data( 'scale-logo' ) ) {
+			var $img = $mh.find( '.site-branding img' ),
+			    imgWidth = $img.width(),
+			    imgHeight = $img.height();
+
 			var smResizeLogo = function () {
-				var top = window.pageYOffset || document.documentElement.scrollTop;
+				var $branding = $mh.find( '.site-branding > *' ),
+				    top = window.pageYOffset || document.documentElement.scrollTop;
 				top -= pageTop;
 
-				var $img = $mh.find( '.site-branding img' ),
-					$branding = $mh.find( '.site-branding > *' );
-
-				$img.removeAttr( 'style' );
-				var imgWidth = $img.width(),
-					imgHeight = $img.height();
-
 				if ( top > 0 ) {
-					var scale = 0.775 + ( Math.max( 0, 48 - top ) / 48 * ( 1 - 0.775 ) );
+					var scale = siteoriginNorth.logoScale + ( Math.max( 0, 48 - top ) / 48 * ( 1 - siteoriginNorth.logoScale ) );
+					// If Scale == siteoriginNorth.logoScale, logo is completely scaled
+					if ( scale != siteoriginNorth.logoScale ) {
+						if ( $img.length ) {
+							$img.css( {
+								width: imgWidth * scale,
+								height: imgHeight * scale,
+								'max-width' : 'none'
+							} );
+						}
+						else {
+							$branding.css( 'transform', 'scale(' + scale + ')' );
+						}
 
-					if ( $img.length ) {
-
-						$img.css( {
-							width: imgWidth * scale,
-							height: imgHeight * scale,
-							'max-width' : 'none'
+						$mh.css( {
+							'padding-top': mhPadding.top * scale,
+							'padding-bottom': mhPadding.bottom * scale
 						} );
 					}
-					else {
-						$branding.css( 'transform', 'scale(' + scale + ')' );
-					}
-
-					$mh.css( {
-						'padding-top': mhPadding.top * scale,
-						'padding-bottom': mhPadding.bottom * scale
-					} );
 				}
 				else {
 					if ( ! $img.length ) {
@@ -455,6 +454,7 @@ jQuery( function ( $ ) {
 
 ( function( $ ) {
 	$( window ).load( function() {
+		siteoriginNorth.logoScale = parseFloat( siteoriginNorth.logoScale );
 		// Handle smooth scrolling.
 		if ( siteoriginNorth.smoothScroll ) {
 			$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).not( '.lsow-tab a[href*="#"]:not([href="#"]), .wc-tabs a[href*="#"]:not([href="#"]), .iw-so-tab-title a[href*="#"]:not([href="#"]), .comment-navigation a[href*="#"]' ).northSmoothScroll();

--- a/js/north.js
+++ b/js/north.js
@@ -370,6 +370,8 @@ jQuery( function ( $ ) {
 			var $img = $mh.find( '.site-branding img' ),
 			    imgWidth = $img.width(),
 			    imgHeight = $img.height();
+			    scaledWidth = imgWidth * siteoriginNorth.logoScale;
+			    scaledHeight = imgHeight * siteoriginNorth.logoScale;
 
 			var smResizeLogo = function () {
 				var $branding = $mh.find( '.site-branding > *' ),
@@ -379,7 +381,7 @@ jQuery( function ( $ ) {
 				if ( top > 0 ) {
 					var scale = siteoriginNorth.logoScale + ( Math.max( 0, 48 - top ) / 48 * ( 1 - siteoriginNorth.logoScale ) );
 					// If Scale == siteoriginNorth.logoScale, logo is completely scaled
-					if ( scale != siteoriginNorth.logoScale ) {
+					if ( $img.height() != scaledHeight || $img.width() != scaledWidth ) {
 						if ( $img.length ) {
 							$img.css( {
 								width: imgWidth * scale,


### PR DESCRIPTION
This PR will allow users to manually adjust the sticky logo scaling amount via the filter `siteorigin_north_logo_sticky_scale`.

Here's example PHP that could be used to change the logo scaling:
```
function so_north_adjust_logo_scaling ( $scale ) {
	return 0.424;
}
add_filter( 'siteorigin_north_logo_sticky_scale', 'so_north_adjust_logo_scaling' );
```

This PR will also prevent the constant recalculation that occurs once the logo has completely scaled. Here's a video example of that (refer to the logo markup after scroll completion): https://drive.google.com/a/siteorigin.com/uc?id=1K3fXVFUgaEFVnHH0ibpsVe5WgIgV3aKO