### PR TITLE
Close Header Search JS - Remove global $.click()

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -434,13 +434,9 @@ jQuery( function ( $ ) {
 	} );
 
 	// Close the header search when clicking outside of the search field or open search button.
-	$( document ).click( function() {
-	    $( '#close-search.animate-in' ).trigger( 'click' );
-	} );
-
-	$( '.north-search-icon, #header-search form' ).click( function() {
-		return false;
-	} );	
+	$( '#header-search input[type=search]' ).on('focusout', function(e) {
+		$( '#close-search.animate-in' ).trigger( 'click' );
+	});
 
 	// Close search with escape key.
 	$( document ).keyup( function( e ) {


### PR DESCRIPTION
This change allows for the loss of focus for non-mouse users and it also prevents a click on `#close-search.animate-in` regardless of visibility.