### PR TITLE
Logo Scale: Remove max-width

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -350,7 +350,6 @@ jQuery( function( $ ) {
 						$( '.site-branding img' ).css( {
 							width: imgWidth * scale,
 							height: imgHeight * scale,
-							'max-width' : 'none'
 						} );
 					}
 				} else {


### PR DESCRIPTION
This PR fixes these two issues:

Allows for more consistent larger logo sizes after scroll (and scrolling back to the top of the page).
prevents the logo from exceeding the browser width on mobile