### PR TITLE
Logo Scaling Retina Sizing

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -421,8 +421,8 @@ jQuery( function( $ ) {
 
 		if ( $mh.data( 'scale-logo' ) ) {
 			var $img = $mh.find( '.site-branding img' ),
-				imgWidth = $img.get(0).naturalWidth,
-				imgHeight = $img.get(0).naturalHeight,
+				imgWidth = $img.attr( 'width' ),
+				imgHeight = $img.attr( 'height' ),
 				scaledWidth = imgWidth * siteoriginNorth.logoScale,
 				scaledHeight = imgHeight * siteoriginNorth.logoScale;
 

--- a/sass/elements/_elements.scss
+++ b/sass/elements/_elements.scss
@@ -37,9 +37,11 @@ figure {
 	margin-right: 0;
 }
 
-img {
-	height: auto; /* Make sure images are scaled correctly. */
-	max-width: 100%; /* Adhere to container width. */
+#topbar-widgets, .site-content, .site-footer {
+	img {
+		height: auto; /* Make sure images are scaled correctly. */
+		max-width: 100%; /* Adhere to container width. */
+	}
 }
 
 code {

--- a/style.css
+++ b/style.css
@@ -341,7 +341,7 @@ figure {
   margin-left: 0;
   margin-right: 0; }
 
-img {
+#topbar-widgets img, .site-content img, .site-footer img {
   height: auto;
   /* Make sure images are scaled correctly. */
   max-width: 100%;


### PR DESCRIPTION
Currently, the retina dimensions were being used rather than the base image dimensions. This PR ensures the retina logo correctly uses the base image dimensions.