### PR TITLE
Removed resetMenu function

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -154,18 +154,6 @@ jQuery( function( $ ) {
 			container: ".search-form"
 		} );
 
-		var resetMenu = function() {
-			$( '.main-navigation ul ul' ).each( function() {
-				var $$ = $( this );
-				var width = Math.max.apply( Math, $$.find( '> li > a' ).map( function() {
-					return $( this ).width();
-				} ).get() );
-				$$.find( '> li > a' ).width( width );
-			} );
-		};
-		resetMenu();
-		$( window ).resize( resetMenu );
-
 		var alignMenu = function() {
 			$( '#primary-menu > li > ul.sub-menu' ).each( function() {
 				var $$ = $( this );


### PR DESCRIPTION
The issue this aims to resolve is as follows:

1. To view the issue, go back to the `develop` branch. Set your mobile responsive breakpoint to 400 or any value that will show the mobile menu on landscape and not on portrait on a mobile device.

2. Load the site in portrait and then rotate to landscape. Ensure you have a menu item with a drop-down. Tap on the drop-down parent.

3. You'll see the sub-menu width is incorrect. `$( window ).on( 'resize orientationchange', resetMenu );` doesn't resolve this issue.

I can't see why the sub-menu width is being set with JavaScript. I can't find any problems in testing after removing the function. Removing the `resetMenu` resolves the issue outlined above.