### PR TITLE
Improve Search Label Accessibility

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -1,7 +1,6 @@
 <form method="get" action="<?php echo esc_url( home_url( '/' ) ) ?>">
-	<label for='s' class='screen-reader-text'><?php esc_html_e( 'Search for:', 'siteorigin-north' ); ?></label>
-	<input type="search" name="s" placeholder="<?php esc_attr_e('Search', 'siteorigin-north') ?>" value="<?php echo get_search_query() ?>" />
-	<button type="submit">
-		<i class="north-icon-search"><label class="screen-reader-text"><?php esc_html_e( 'Search', 'siteorigin-north' ); ?></label></i>
+	<input type="search" name="s" aria-label="<?php esc_html_e( 'Search for', 'siteorigin-north' ); ?>" placeholder="<?php esc_attr_e('Search', 'siteorigin-north') ?>" value="<?php echo get_search_query() ?>" />
+	<button type="submit" aria-label="<?php esc_html_e( 'Search', 'siteorigin-north' ); ?>">
+		<i class="north-icon-search"></i>
 	</button>
 </form>


### PR DESCRIPTION
This PR resolves an accessibility issue with the search form labels for the text field and button.

This PR makes [this CSS](https://github.com/siteorigin/siteorigin-corp/blob/develop/sass/modules/_accessibility.scss#L2-L28) redundant. @Misplon Are you okay with removing that CSS? It was only being searchform.php, but due to the context, I thought I should double check.