### PR TITLE
Hide Mobile Menu When Menu is Empty and Menu Search is Disabled

### DIFF
--- a/header.php
+++ b/header.php
@@ -87,14 +87,13 @@
 
 								<?php
 								$menu_id = ( wp_get_nav_menu_name( 'primary' ) ? wp_get_nav_menu_name( 'primary' ) : false );
-
-								var_dump( 123 );
-								if ( class_exists( 'Woocommerce' ) ) :
+								if ( class_exists( 'Woocommerce' ) ) {
 									// Work out if the WooComemrce cart is enabled and showing
-									if ( ( ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_cart' ) ) || ( ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_checkout_cart' ) ) ) :
+									if ( ( ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_cart' ) ) || ( ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_checkout_cart' ) ) ) {
 										$show_min_cart = true;
-									endif;
-								endif;
+									}
+								}
+
 								if ( ( $menu_id && wp_get_nav_menu_object( $menu_id )->count ) || siteorigin_setting( 'navigation_search' ) || isset( $show_min_cart ) ) : ?>
 
 									<a href="#menu" id="mobile-menu-button">
@@ -114,7 +113,7 @@
 								) );
 								?>
 								<?php
-									if ( isset( $show_min_cart ) ) {
+									if ( isset( $show_min_cart ) ) :
 										global $woocommerce;
 										?>
 										<ul class="shopping-cart">

--- a/header.php
+++ b/header.php
@@ -85,15 +85,21 @@
 
 							<?php else : ?>
 
-								<a href="#menu" id="mobile-menu-button">
-									<?php siteorigin_north_display_icon( 'menu' ) ?>
-									<?php if ( siteorigin_setting( 'responsive_menu_text' ) ) : ?>
-										<?php echo esc_html( siteorigin_setting( 'responsive_menu_text' ) ); ?>
-										<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'siteorigin-north' ); ?></span>
-									<?php endif; ?>
-								</a>
+								<?php
+								$menu_id = ( wp_get_nav_menu_name( 'primary' ) ? wp_get_nav_menu_name( 'primary' ) :  false );
+								if ( wp_get_nav_menu_object( $menu_id )->count || siteorigin_setting( 'navigation_search' ) ) : ?>
+
+									<a href="#menu" id="mobile-menu-button">
+										<?php siteorigin_north_display_icon( 'menu' ) ?>
+										<?php if ( siteorigin_setting( 'responsive_menu_text' ) ) : ?>
+											<?php echo esc_html( siteorigin_setting( 'responsive_menu_text' ) ); ?>
+											<span class="screen-reader-text"><?php esc_html_e( 'Menu', 'siteorigin-north' ); ?></span>
+										<?php endif; ?>
+									</a>
 
 								<?php
+								endif;
+
 								wp_nav_menu( array(
 									'theme_location' => 'primary',
 									'menu_id' => 'primary-menu'

--- a/header.php
+++ b/header.php
@@ -90,11 +90,11 @@
 								if ( class_exists( 'Woocommerce' ) ) {
 									// Work out if the WooComemrce cart is enabled and showing
 									if ( ( ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_cart' ) ) || ( ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_checkout_cart' ) ) ) {
-										$show_min_cart = true;
+										$show_mini_cart = true;
 									}
 								}
 
-								if ( ( $menu_id && wp_get_nav_menu_object( $menu_id )->count ) || siteorigin_setting( 'navigation_search' ) || isset( $show_min_cart ) ) : ?>
+								if ( ( $menu_id && wp_get_nav_menu_object( $menu_id )->count ) || siteorigin_setting( 'navigation_search' ) || isset( $show_mini_cart ) ) : ?>
 
 									<a href="#menu" id="mobile-menu-button">
 										<?php siteorigin_north_display_icon( 'menu' ) ?>
@@ -113,7 +113,7 @@
 								) );
 								?>
 								<?php
-									if ( isset( $show_min_cart ) ) :
+									if ( isset( $show_mini_cart ) ) :
 										global $woocommerce;
 										?>
 										<ul class="shopping-cart">

--- a/header.php
+++ b/header.php
@@ -88,7 +88,7 @@
 								<?php
 								$menu_id = ( wp_get_nav_menu_name( 'primary' ) ? wp_get_nav_menu_name( 'primary' ) : false );
 								if ( class_exists( 'Woocommerce' ) ) {
-									// Work out if the WooComemrce cart is enabled and showing
+									// Work out if the WooCommerce cart is enabled and showing
 									if ( ( ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_cart' ) ) || ( ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_checkout_cart' ) ) ) {
 										$show_mini_cart = true;
 									}

--- a/header.php
+++ b/header.php
@@ -87,7 +87,15 @@
 
 								<?php
 								$menu_id = ( wp_get_nav_menu_name( 'primary' ) ? wp_get_nav_menu_name( 'primary' ) : false );
-								if ( ( $menu_id && wp_get_nav_menu_object( $menu_id )->count ) || siteorigin_setting( 'navigation_search' ) ) : ?>
+
+								var_dump( 123 );
+								if ( class_exists( 'Woocommerce' ) ) :
+									// Work out if the WooComemrce cart is enabled and showing
+									if ( ( ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_cart' ) ) || ( ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_checkout_cart' ) ) ) :
+										$show_min_cart = true;
+									endif;
+								endif;
+								if ( ( $menu_id && wp_get_nav_menu_object( $menu_id )->count ) || siteorigin_setting( 'navigation_search' ) || isset( $show_min_cart ) ) : ?>
 
 									<a href="#menu" id="mobile-menu-button">
 										<?php siteorigin_north_display_icon( 'menu' ) ?>
@@ -105,26 +113,24 @@
 									'menu_id' => 'primary-menu'
 								) );
 								?>
-
-							<?php endif; ?>
-
-							<?php if ( class_exists( 'Woocommerce' ) && ! ( function_exists( 'ubermenu' ) || function_exists( 'max_mega_menu_is_enabled' ) ) ) : ?>
-								<?php if ( ( ! ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_cart' ) ) || ( ( is_cart() || is_checkout() ) && siteorigin_setting( 'woocommerce_display_checkout_cart' ) ) ) : ?>
-									<?php global $woocommerce; ?>
-									<ul class="shopping-cart">
-										<li>
-											<a class="shopping-cart-link" href="<?php echo esc_url( wc_get_cart_url() ); ?>">
-												<span class="screen-reader-text"><?php esc_html_e( 'View shopping cart', 'siteorigin-north' ); ?></span>
-												<span class="north-icon-cart"></span>
-												<span class="shopping-cart-text"><?php esc_html_e( ' View Cart ', 'siteorigin-north' ); ?></span>
-												<span class="shopping-cart-count"><?php echo WC()->cart->cart_contents_count;?></span>
-											</a>
-											<ul class="shopping-cart-dropdown" id="cart-drop">
-												<?php the_widget( 'WC_Widget_Cart' ); ?>
-											</ul>
-										</li>
-									</ul>
-								<?php endif; ?>
+								<?php
+									if ( isset( $show_min_cart ) ) {
+										global $woocommerce;
+										?>
+										<ul class="shopping-cart">
+											<li>
+												<a class="shopping-cart-link" href="<?php echo esc_url( wc_get_cart_url() ); ?>">
+													<span class="screen-reader-text"><?php esc_html_e( 'View shopping cart', 'siteorigin-north' ); ?></span>
+													<span class="north-icon-cart"></span>
+													<span class="shopping-cart-text"><?php esc_html_e( ' View Cart ', 'siteorigin-north' ); ?></span>
+													<span class="shopping-cart-count"><?php echo WC()->cart->cart_contents_count;?></span>
+												</a>
+												<ul class="shopping-cart-dropdown" id="cart-drop">
+													<?php the_widget( 'WC_Widget_Cart' ); ?>
+												</ul>
+											</li>
+										</ul>
+									<?php endif; ?>
 							<?php endif; ?>
 
 							<?php if ( siteorigin_setting( 'navigation_search' ) && ! ( function_exists( 'ubermenu' ) || function_exists( 'max_mega_menu_is_enabled' ) ) ) : ?>

--- a/header.php
+++ b/header.php
@@ -86,8 +86,8 @@
 							<?php else : ?>
 
 								<?php
-								$menu_id = ( wp_get_nav_menu_name( 'primary' ) ? wp_get_nav_menu_name( 'primary' ) :  false );
-								if ( wp_get_nav_menu_object( $menu_id )->count || siteorigin_setting( 'navigation_search' ) ) : ?>
+								$menu_id = ( wp_get_nav_menu_name( 'primary' ) ? wp_get_nav_menu_name( 'primary' ) : false );
+								if ( ( $menu_id && wp_get_nav_menu_object( $menu_id )->count ) || siteorigin_setting( 'navigation_search' ) ) : ?>
 
 									<a href="#menu" id="mobile-menu-button">
 										<?php siteorigin_north_display_icon( 'menu' ) ?>

--- a/js/north.js
+++ b/js/north.js
@@ -192,7 +192,7 @@ jQuery( function( $ ) {
 
 		if ( $mobileMenu === false ) {
 			$mobileMenu = $( '<div></div>' )
-				.append( $( '.main-navigation ul.menu' ).first().clone() )
+				.append( $( '.main-navigation .menu ul, .main-navigation ul.menu' ).first().clone() )
 				.attr( 'id', 'mobile-navigation' )
 				.appendTo( '#masthead' ).hide();
 

--- a/js/north.js
+++ b/js/north.js
@@ -200,10 +200,6 @@ jQuery( function( $ ) {
 				$mobileMenu.append( $( '#header-search form' ).clone() );
 			}
 
-			if ( $( '.main-navigation .shopping-cart' ).length ) {
-				$mobileMenu.append( $( '.main-navigation .shopping-cart .shopping-cart-link' ).clone() );
-			}
-
 			$mobileMenu.find( '#primary-menu' ).show().css( 'opacity', 1 );
 
 			$mobileMenu.find( '.menu-item-has-children > a' ).addClass( 'has-dropdown' );

--- a/js/north.js
+++ b/js/north.js
@@ -192,12 +192,16 @@ jQuery( function( $ ) {
 
 		if ( $mobileMenu === false ) {
 			$mobileMenu = $( '<div></div>' )
-				.append( $( '.main-navigation ul' ).first().clone() )
+				.append( $( '.main-navigation ul.menu' ).first().clone() )
 				.attr( 'id', 'mobile-navigation' )
 				.appendTo( '#masthead' ).hide();
 
 			if ( $( '#header-search form' ).length ) {
 				$mobileMenu.append( $( '#header-search form' ).clone() );
+			}
+
+			if ( $( '.main-navigation .shopping-cart' ).length ) {
+				$mobileMenu.append( $( '.main-navigation .shopping-cart .shopping-cart-link' ).clone() );
 			}
 
 			$mobileMenu.find( '#primary-menu' ).show().css( 'opacity', 1 );


### PR DESCRIPTION
This PR will hide the mobile menu when the menu is empty _and_ the Menu Search is disabled. Previously the mobile menu would show but it would be completely empty.

![](https://i.imgur.com/hi0N67D.gif)