### PR TITLE
Prevent long titles overlapping remove icon

### DIFF
--- a/sass/woocommerce/_cart.scss
+++ b/sass/woocommerce/_cart.scss
@@ -375,7 +375,7 @@
 					font-weight: 700;
 					line-height: normal;
 					margin: 0 0 7px 0;
-					padding: 0 !important;
+					padding: 0 20px 0 0 !important;
 					text-decoration: none;
 				}
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -588,7 +588,7 @@
         font-weight: 700;
         line-height: normal;
         margin: 0 0 7px 0;
-        padding: 0 !important;
+        padding: 0 20px 0 0 !important;
         text-decoration: none; }
       .widget_shopping_cart .widget_shopping_cart_content .cart_list .mini_cart_item img {
         float: left;


### PR DESCRIPTION
Long product titles can overlap the remove icon. This PR prevents that from happening.