### PR TITLE
Delcare heading sizes

### DIFF
--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -7,6 +7,7 @@ h6 {
 	font-weight: normal;
 	font-family: $font__headings;
 	color: $color__text_dark;
+	margin: 25px 0;
 
 	.widget & {
 		color: inherit;

--- a/sass/typography/_headings.scss
+++ b/sass/typography/_headings.scss
@@ -12,3 +12,27 @@ h6 {
 		color: inherit;
 	}
 }
+
+h1 {
+	font-size: 29px;
+}
+
+h2 {
+	font-size: 25px;
+}
+
+h3 {
+	font-size: 22px;
+}
+
+h4 {
+	font-size: 20px;
+}
+
+h5 {
+	font-size: 18px;
+}
+
+h6 {
+	font-size: 16px;
+}

--- a/style.css
+++ b/style.css
@@ -254,6 +254,24 @@ h6 {
   h6 {
     color: inherit; }
 
+h1 {
+  font-size: 29px; }
+
+h2 {
+  font-size: 25px; }
+
+h3 {
+  font-size: 22px; }
+
+h4 {
+  font-size: 20px; }
+
+h5 {
+  font-size: 18px; }
+
+h6 {
+  font-size: 16px; }
+
 p {
   margin-bottom: 1.5em; }
 

--- a/style.css
+++ b/style.css
@@ -245,7 +245,8 @@ h5,
 h6 {
   font-weight: normal;
   font-family: "Montserrat", sans-serif;
-  color: #292929; }
+  color: #292929;
+  margin: 25px 0; }
   .widget h1, .widget
   h2, .widget
   h3, .widget


### PR DESCRIPTION
North is currently falling back largely on user-agent heading styles and spacing. You can see the issue with this when using the Beautifully Baked prebuilt layout which uses `h5` headings. This PR is quite heavy-handed but, I think necessary. It adds basic heading sizing and spacing. The sizing is using 1.125 (Major Second) as the type scale with 14px/1em as the base. The visual impact on existing content will be minimal but please, check out some existing content and let me know.