### PR TITLE
Ensure WC archive buttons align correctly

### DIFF
--- a/sass/woocommerce/_archives.scss
+++ b/sass/woocommerce/_archives.scss
@@ -158,26 +158,29 @@
 					font-family: $font__detail;
 					color: $color__primary_accent;
 				}
+
+				.button {
+					margin-right: 5px;
+					margin-left: 5px;
+				}
 			}
 		}
 
 		@at-root .woocommerce.equalize-rows #main ul.products {
 			display: flex;
 			flex-wrap: wrap;
-			justify-content: space-between;
-			
+
 			li {
+				align-content: space-between;
 				display: flex;
 				flex-wrap: wrap;
-				
+
 				@media (max-width: 600px) {
 					display: block;	
 				}
 
-				.button {
-					margin-top: auto;
-					margin-right: auto;
-					margin-left: auto;
+				div {
+					margin: auto;
 				}
 			}
 		}

--- a/style.css
+++ b/style.css
@@ -2260,3 +2260,5 @@ object {
     background: #000;
     opacity: 0.1;
     border-radius: 10px; }
+
+/*# sourceMappingURL=sass/maps/style.css.map */

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -128,21 +128,22 @@
   .woocommerce #main ul.products li.product .price {
     font-family: "Droid Serif", sans-serif;
     color: #c75d5d; }
+  .woocommerce #main ul.products li.product .button {
+    margin-right: 5px;
+    margin-left: 5px; }
 
 .woocommerce.equalize-rows #main ul.products {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between; }
+  flex-wrap: wrap; }
   .woocommerce.equalize-rows #main ul.products li {
+    align-content: space-between;
     display: flex;
     flex-wrap: wrap; }
     @media (max-width: 600px) {
       .woocommerce.equalize-rows #main ul.products li {
         display: block; } }
-    .woocommerce.equalize-rows #main ul.products li .button {
-      margin-top: auto;
-      margin-right: auto;
-      margin-left: auto; }
+    .woocommerce.equalize-rows #main ul.products li div {
+      margin: auto; }
 
 /*--------------------------------------------------------------
 # WooCommerce Element Styles

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -21,6 +21,9 @@ function siteorigin_north_woocommerce_change_hooks(){
 	remove_action( 'woocommerce_cart_collaterals', 'woocommerce_cart_totals', 10 );
 	remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 
+	// Product archive buttons.
+	remove_action( 'woocommerce_after_shop_loop_item', 'woocommerce_template_loop_add_to_cart' );
+
 	// Quick view action hooks.
 	add_action( 'siteorigin_north_woocommerce_quick_view_images', 'siteorigin_north_woocommerce_quick_view_image', 5 );
 	add_action( 'siteorigin_north_woocommerce_quick_view_title', 'woocommerce_template_single_price', 5 );
@@ -178,12 +181,25 @@ if ( ! function_exists( 'siteorigin_north_woocommerce_quick_view_button' ) ) :
  */
 function siteorigin_north_woocommerce_quick_view_button() {
 	global $product;
-	if( siteorigin_setting( 'woocommerce_display_quick_view' ) ) :
-		echo '<a href="#" id="product-id-' . $product->get_id() . '" class="button product-quick-view-button" data-product-id="' . $product->get_id() . '">' . __( 'Quick View', 'siteorigin-north') . '</a>';
-	endif;
+	echo '<a href="#" id="product-id-' . $product->get_id() . '" class="button product-quick-view-button" data-product-id="' . $product->get_id() . '">' . __( 'Quick View', 'siteorigin-north') . '</a>';
 }
 endif;
-add_action( 'woocommerce_after_shop_loop_item', 'siteorigin_north_woocommerce_quick_view_button', 5 );
+
+if ( ! function_exists( 'siteorigin_north_woocommerce_archive_buttons' ) ) :
+/**
+ * Archive product buttons.
+ */
+function siteorigin_north_woocommerce_archive_buttons() { ?>
+	<div>
+		<?php if ( siteorigin_setting( 'woocommerce_display_quick_view' ) ) {
+			siteorigin_north_woocommerce_quick_view_button();
+		}
+		woocommerce_template_loop_add_to_cart();
+		?>
+	</div>
+<?php }
+endif;
+add_action( 'woocommerce_after_shop_loop_item', 'siteorigin_north_woocommerce_archive_buttons' );
 
 if ( ! function_exists('siteorigin_north_woocommerce_quick_view ') ) :
 /**

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -191,10 +191,12 @@ if ( ! function_exists( 'siteorigin_north_woocommerce_archive_buttons' ) ) :
  */
 function siteorigin_north_woocommerce_archive_buttons() { ?>
 	<div>
-		<?php if ( siteorigin_setting( 'woocommerce_display_quick_view' ) ) {
-			siteorigin_north_woocommerce_quick_view_button();
-		}
-		woocommerce_template_loop_add_to_cart();
+		<?php
+			if ( siteorigin_setting( 'woocommerce_display_quick_view' ) ) {
+				siteorigin_north_woocommerce_quick_view_button();
+			}
+
+			woocommerce_template_loop_add_to_cart();
 		?>
 	</div>
 <?php }


### PR DESCRIPTION
Resolves button alignment issue that occurs when both WC archive buttons are present and the equal column height setting is used.

![Shop_-_North-02](https://user-images.githubusercontent.com/789159/68496404-ea556a80-025a-11ea-93ed-c8df87224d3f.png)

![Shop_-_North](https://user-images.githubusercontent.com/789159/68496206-71561300-025a-11ea-91bc-cdc5bf07fd1d.png)
