### PR TITLE
Update setting description and mobile padding

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -433,8 +433,8 @@ function siteorigin_north_settings_init() {
 				),
 				'side_padding'     => array(
 					'type'              => 'measurement',
-					'label'             => __( 'Widget Left-Right Padding', 'siteorigin-north' ),
-					'description' 		=> __( "Set the left and right padding for each widget.", 'siteorigin-north' ),
+					'label'             => __( 'Widget Side Padding', 'siteorigin-north' ),
+					'description'       => __( "Set the left and right padding for each widget.", 'siteorigin-north' ),
 					'live'              => true,
 				),
 				'top_margin'       => array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -433,8 +433,8 @@ function siteorigin_north_settings_init() {
 				),
 				'side_padding'     => array(
 					'type'              => 'measurement',
-					'label'             => __( 'Side Padding', 'siteorigin-north' ),
-					'description' 		=> __( "Only applied when footer width is unconstrained.", 'siteorigin-north' ),
+					'label'             => __( 'Widget Left-Right Padding', 'siteorigin-north' ),
+					'description' 		=> __( "Set the left and right padding for each widget.", 'siteorigin-north' ),
 					'live'              => true,
 				),
 				'top_margin'       => array(

--- a/sass/site/primary/_footer.scss
+++ b/sass/site/primary/_footer.scss
@@ -31,6 +31,14 @@
 			&:last-child {
 				border-right: none;
 			}
+
+			aside {
+
+				@media (max-width: 640px) {
+					padding-right: 0;
+					padding-left: 0;
+				}
+			}
 		}
 
 		aside {

--- a/style.css
+++ b/style.css
@@ -1541,6 +1541,10 @@ body.page-layout-stripped #main.site-main {
       margin-bottom: -9999px; }
       #colophon .widgets .widget-wrapper:last-child {
         border-right: none; }
+      @media (max-width: 640px) {
+        #colophon .widgets .widget-wrapper aside {
+          padding-right: 0;
+          padding-left: 0; } }
     #colophon .widgets aside {
       padding: 40px 40px;
       margin: 0; }


### PR DESCRIPTION
Resolves #387.

Side padding suggests the setting is for the entire footer side padding, instead, this setting is applying side padding to each footer widget, the setting label has been updated to reflect that.

Side padding wasn't only applied to the footer widgets when the width was unconstrained. I've updated the setting description to reflect the true behavior of the setting.

Finally, side padding of say 100px is problematic on mobile. I've removed side padding for mobile. This leaves the footer widgets to match the rest of the theme left-right padding for mobile.