### PR TITLE
Smooth scroll: Allow external page jumps to work

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -60,39 +60,46 @@
 		};
 
 		$.fn.northSmoothScroll = function() {
+			$target = $( this );
+			if ( $target.length ) {
+
+				var height = 0;
+				if ( $( '#masthead' ).hasClass( 'sticky-menu' ) && $( '#masthead' ).data( 'scale-logo' ) ) {
+					if ( $target.offset().top < 48 ) {
+						height += $( '#masthead' ).outerHeight();
+					} else if ( $( '.site-branding' ).outerHeight() > $( '#site-navigation' ).outerHeight() ) {
+						height += $( '#masthead' ).outerHeight() * siteoriginNorth.logoScale;
+					} else {
+						height += $( '#masthead' ).height() + ( $( '#masthead' ).innerHeight() - $( '#masthead' ).height() );
+					}
+				} else if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
+					height += $( '#masthead' ).outerHeight();
+				}
+
+				if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
+					height += $( '#wpadminbar' ).outerHeight();
+				}
+
+				$( 'html, body' ).animate( {
+					scrollTop: $target.offset().top - height
+				}, 1000 );
+
+				return false;
+			}
+			// Scroll to the position of the item, minus the header size.
+		}
+
+		$.fn.northSmoothScrollClick = function() {
 			$( this ).click( function( e ) {
 				var $a = $( this );
 				var $target = $( '[name=' + this.hash.slice( 1 ) + ']' ).length ? $( '[name=' + this.hash.slice( 1 ) + ']' ) : $( $a.get( 0 ).hash );
 
 				if ( $target.length ) {
-
-					var height = 0;
-					if ( $( '#masthead' ).hasClass( 'sticky-menu' ) && $( '#masthead' ).data( 'scale-logo' ) ) {
-						if ( $target.offset().top < 48 ) {
-							height += $( '#masthead' ).outerHeight();
-						} else if ( $( '.site-branding' ).outerHeight() > $( '#site-navigation' ).outerHeight() ) {
-							height += $( '#masthead' ).outerHeight() * siteoriginNorth.logoScale;
-						} else {
-							height += $( '#masthead' ).height() + ( $( '#masthead' ).innerHeight() - $( '#masthead' ).height() );
-						}
-					} else if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
-						height += $( '#masthead' ).outerHeight();
-					}
-
-					if ( $( 'body' ).hasClass( 'admin-bar' ) ) {
-						height += $( '#wpadminbar' ).outerHeight();
-					}
-
-					$( 'html, body' ).animate( {
-						scrollTop: $target.offset().top - height
-					}, 1000 );
-
-					return false;
+					$target.northSmoothScroll();
 				}
-				// Scroll to the position of the item, minus the header size.
+
 			} );
 		}
-
 	}
 )( jQuery );
 
@@ -250,7 +257,7 @@ jQuery( function( $ ) {
 		} );
 
 		if ( siteoriginNorth.smoothScroll ) {
-			$( '#mobile-navigation a[href*="#"]:not([href="#"])' ).northSmoothScroll();
+			$( '#mobile-navigation a[href*="#"]:not([href="#"])' ).northSmoothScrollClick();
 		}
 
 	} );

--- a/js/north.js
+++ b/js/north.js
@@ -328,13 +328,20 @@ jQuery( function( $ ) {
 } );
 
 ( function( $ ) {
-	$( window ).load( function() {
-		siteoriginNorth.logoScale = parseFloat( siteoriginNorth.logoScale );
+	if ( siteoriginNorth.smoothScroll ) {
+		// Detect potential page jump on load and prevent it.
+		if ( location.hash ) {
+			if ( $( location.hash ).length ) {
+				setTimeout( function() {
+					window.scrollTo( 0, 0 );
+				}, 1 );
 
-		// Handle smooth scrolling.
-		if ( siteoriginNorth.smoothScroll ) {
-			$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).not( '.lsow-tab a[href*="#"]:not([href="#"]), .wc-tabs a[href*="#"]:not([href="#"]), .iw-so-tab-title a[href*="#"]:not([href="#"]), .comment-navigation a[href*="#"]' ).northSmoothScroll();
+				var scrollOnLoad = true;
+			}
 		}
+	}
+	$( window ).load( function( e ) {
+		siteoriginNorth.logoScale = parseFloat( siteoriginNorth.logoScale );
 
 		var $mh = $( '#masthead' ),
 			mhPadding = {
@@ -461,5 +468,17 @@ jQuery( function( $ ) {
 			smSetup();
 			$( window ).resize( smSetup ).scroll( smSetup );
 		}
+
+		// Handle smooth scrolling.
+		if ( siteoriginNorth.smoothScroll ) {
+			if ( typeof scrollOnLoad != 'undefined' ) {
+				setTimeout(
+					$( location.hash ).northSmoothScroll(),
+					100
+				);
+			}
+			$( '#site-navigation a[href*="#"]:not([href="#"])' ).add( 'a[href*="#"]:not([href="#"])' ).not( '.lsow-tab a[href*="#"]:not([href="#"]), .wc-tabs a[href*="#"]:not([href="#"]), .iw-so-tab-title a[href*="#"]:not([href="#"]), .comment-navigation a[href*="#"]' ).northSmoothScrollClick();
+		}
+
 	} );
 } )( jQuery );


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-north/issues/390

This PR allows for external links to trigger page jump by checking for a location hash on load.

The Smooth scroll function was previously locked click() so to prevent code duplication I had to introduce `northSmoothScrollClick`. This means that there is a chance that the old smooth scroll may have broken. Please confirm the following works as expected:

- Standard page jump link
- Navigation page jump link
