### PR TITLE
Exclude Logo from WP 5.5 Lazy Load

### DIFF
--- a/inc/jetpack.php
+++ b/inc/jetpack.php
@@ -27,31 +27,6 @@ function siteorigin_north_jetpack_setup() {
 endif;
 add_action( 'after_setup_theme', 'siteorigin_north_jetpack_setup' );
 
-if ( Jetpack::is_module_active( 'lazy-images' ) ) :
-	if (  ! function_exists( 'siteorigin_north_jetpack_logo_not_lazy' ) ) {
-
-		function siteorigin_north_jetpack_logo_not_lazy( $blacklisted_classes ) {
-			$blacklisted_classes[] = 'custom-logo';
-
-			return $blacklisted_classes;
-		}
-		add_filter( 'jetpack_lazy_images_blacklisted_classes', 'siteorigin_north_jetpack_logo_not_lazy' );
-	}
-
-	if ( ! function_exists( 'siteorigin_north_jetpack_logo_not_lazy_class' ) ) {
-
-		function siteorigin_north_jetpack_logo_not_lazy_class( $attrs ) {
-			if ( ! empty( $attrs['class'] ) ) {
-				$attrs['class'] .= ' skip-lazy';
-			} else {
-				$attrs['class'] = 'skip-lazy';
-			}
-
-			return $attrs;
-		}
-		add_filter( 'siteorigin_north_logo_attributes', 'siteorigin_north_jetpack_logo_not_lazy_class' );
-	}
-endif;
 
 if ( ! function_exists( 'siteorigin_north_infinite_scroll_render' ) ) :
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -78,39 +78,35 @@ function siteorigin_north_display_retina_logo( $attr ) {
 endif;
 add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_north_display_retina_logo' );
 
-if (
-	class_exists( 'Smush\Core\Modules\Lazy' ) ||
-	class_exists( 'LiteSpeed_Cache' ) ||
-	class_exists( 'Jetpack_Lazy_Images' )
-) :
-	if ( ! function_exists( 'siteorigin_north_lazy_load_exclude' ) ) :
-		/**
-		 * Exclude Logo from Lazy Load plugins.
-		 */
-		function siteorigin_north_lazy_load_exclude( $attr, $attachment ) {
-			$custom_logo_id = siteorigin_setting( 'branding_logo' );
-			if ( empty( $custom_logo_id ) ) {
-				$custom_logo_id = get_theme_mod( 'custom_logo' );
-			}
-			if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
-				// Jetpack Lazy Load
-				if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
-					$attr['class'] .= ' skip-lazy';
-				}
-				// Smush Lazy Load
-				if ( class_exists( 'Smush\Core\Modules\Lazy' ) ) {
-					$attr['class'] .= ' no-lazyload';
-				}
-				// LiteSpeed Cache Lazy Load
-				if ( class_exists( 'LiteSpeed_Cache' ) ) {
-					$attr['data-no-lazy'] = 1;
-				}
-			}
-			return $attr;
+if ( ! function_exists( 'siteorigin_north_lazy_load_exclude' ) ) :
+	/**
+	 * Exclude Logo from Lazy Load plugins.
+	 */
+	function siteorigin_north_lazy_load_exclude( $attr, $attachment ) {
+		$custom_logo_id = siteorigin_setting( 'branding_logo' );
+		if ( empty( $custom_logo_id ) ) {
+			$custom_logo_id = get_theme_mod( 'custom_logo' );
 		}
-	endif;
-	add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_north_lazy_load_exclude', 10, 2 );
+		if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
+			// Jetpack Lazy Load
+			if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
+				$attr['class'] .= ' skip-lazy';
+			}
+			// Smush Lazy Load
+			if ( class_exists( 'Smush\Core\Modules\Lazy' ) ) {
+				$attr['class'] .= ' no-lazyload';
+			}
+			// LiteSpeed Cache Lazy Load
+			if ( class_exists( 'LiteSpeed_Cache' ) ) {
+				$attr['data-no-lazy'] = 1;
+			}
+			// WP 5.5
+			$attr['loading'] = false;
+		}
+		return $attr;
+	}
 endif;
+add_filter( 'wp_get_attachment_image_attributes', 'siteorigin_north_lazy_load_exclude', 10, 2 );
 
 if ( ! function_exists( 'siteorigin_north_the_post_navigation' ) ) :
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -97,7 +97,7 @@ if ( ! function_exists( 'siteorigin_north_lazy_load_exclude' ) ) :
 				$attr['class'] .= ' no-lazyload';
 			}
 			// LiteSpeed Cache Lazy Load
-			if ( class_exists( 'LiteSpeed_Cache' ) ) {
+			if ( class_exists( 'LiteSpeed_Cache' ) || class_exists( 'LiteSpeed\Media' ) ) {
 				$attr['data-no-lazy'] = 1;
 			}
 			// WP 5.5


### PR DESCRIPTION
This PR is required for https://github.com/siteorigin/siteorigin-north/pull/395. Without it, the placement of the page jump lazy load is incorrect in Firefox.

How Firefox handles the lazy loading causes the page jump to be different to the smooth scroll. This PR disables the lazy loading on the logo to prevent the image from "popping in" much later while using Firefox. That delay causes the header size to be calculated incorrectly on load.