### PR TITLE
check get_the_terms result is boolean or array at single-product/meta-undertitle.php

### DIFF
--- a/woocommerce/single-product/meta-undertitle.php
+++ b/woocommerce/single-product/meta-undertitle.php
@@ -12,7 +12,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 global $post, $product;
-$cat_count = sizeof( get_the_terms( $post->ID, 'product_cat' ) );
+$cat_count = get_the_terms( $post->ID, 'product_cat' );
+if ( $cat_count == false ){
+    $cat_count = 0;
+}
+else{
+    $cat_count = sizeof( $cat_count );
+}
 ?>
 <div class="product-under-title-meta">
 


### PR DESCRIPTION
When the product has no category set, ```get_the_terms``` would return as ```boolean``` and sizeof triggers a warning to generate.

The fix checks the result of ```get_the_terms``` and acts accordingly.