### PR TITLE
Update Jetpack Lazy Image logo exclude

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -89,7 +89,7 @@ if ( ! function_exists( 'siteorigin_north_lazy_load_exclude' ) ) :
 		}
 		if ( ! empty( $custom_logo_id ) && $attachment->ID == $custom_logo_id ) {
 			// Jetpack Lazy Load
-			if ( class_exists( 'Jetpack_Lazy_Images' ) ) {
+			if ( class_exists( 'Jetpack_Lazy_Images' ) || class_exists( 'Automattic\\Jetpack\\Jetpack_Lazy_Images' ) ) {
 				$attr['class'] .= ' skip-lazy';
 			}
 			// Smush Lazy Load


### PR DESCRIPTION
[Related](https://github.com/siteorigin/siteorigin-unwind/pull/294/commits/18ad88216cd0746caffab8f963299ea35487f4e6)

Jetpack has namespaced their classes, and this PR accounts for that.