### PR TITLE
Ensure that WC archive styling is apploed to sc

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -76,7 +76,11 @@ function siteorigin_north_body_classes( $classes ) {
 			$classes[] = 'equalize-rows';
 		}
 		
-	} elseif ( ! siteorigin_setting( 'masthead_text_above' ) && ! is_active_sidebar( 'topbar-sidebar' ) ) {
+	} if ( wc_post_content_has_shortcode( 'products' ) ) {
+		$classes[] = 'woocommerce';
+	}
+
+	elseif ( ! siteorigin_setting( 'masthead_text_above' ) && ! is_active_sidebar( 'topbar-sidebar' ) ) {
 		$classes[] = 'no-topbar';
 	}
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -574,15 +574,15 @@ function siteorigin_north_settings_custom_css( $css ) {
 	#page ::selection {
 	background-color: ${branding_accent};
 	}
-	button,input[type="button"],input[type="reset"],input[type="submit"] {
+	button,input[type=button],input[type=reset],input[type=submit] {
 	color: ${fonts_text_dark};
 	.font( ${fonts_headings} );
 	}
-	button:hover,button:active,button:focus,input[type="button"]:hover,input[type="button"]:active,input[type="button"]:focus,input[type="reset"]:hover,input[type="reset"]:active,input[type="reset"]:focus,input[type="submit"]:hover,input[type="submit"]:active,input[type="submit"]:focus {
+	button:hover,button:active,button:focus,input[type=button]:hover,input[type=button]:active,input[type=button]:focus,input[type=reset]:hover,input[type=reset]:active,input[type=reset]:focus,input[type=submit]:hover,input[type=submit]:active,input[type=submit]:focus {
 	background: ${branding_accent_dark};
 	border-color: ${branding_accent_dark};
 	}
-	input[type="text"],input[type="email"],input[type="url"],input[type="password"],input[type="search"],input[type="tel"],textarea {
+	input[type=text],input[type=email],input[type=url],input[type=password],input[type=search],input[type=tel],textarea {
 	background: ${fonts_field_background};
 	color: ${fonts_text_medium};
 	.font( ${fonts_details} );
@@ -648,7 +648,7 @@ function siteorigin_north_settings_custom_css( $css ) {
 	#header-search {
 	background: ${masthead_background_color};
 	}
-	#header-search input[type="search"] {
+	#header-search input[type=search] {
 	.font( ${fonts_details} );
 	}
 	#header-search #close-search .svg-icon-close path {
@@ -667,20 +667,20 @@ function siteorigin_north_settings_custom_css( $css ) {
 	background: .rgba( ${responsive_mobile_menu_background_color}, ${responsive_mobile_menu_background_opacity});
 	.font( ${fonts_menu} );
 	}
-	#mobile-navigation form input[type="search"] {
+	#mobile-navigation form input[type=search] {
 	border-bottom: 1px solid ${responsive_mobile_menu_text_color};
 	color: ${responsive_mobile_menu_text_color};
 	}
-	#mobile-navigation form input[type="search"]::-webkit-input-placeholder {
+	#mobile-navigation form input[type=search]::-webkit-input-placeholder {
 	color: .rgba( ${responsive_mobile_menu_text_color}, 0.7);
 	}
-	#mobile-navigation form input[type="search"]::-moz-placeholder {
+	#mobile-navigation form input[type=search]::-moz-placeholder {
 	color: .rgba( ${responsive_mobile_menu_text_color}, 0.7);
 	}
-	#mobile-navigation form input[type="search"]:-moz-placeholder {
+	#mobile-navigation form input[type=search]:-moz-placeholder {
 	color: .rgba( ${responsive_mobile_menu_text_color}, 0.7);
 	}
-	#mobile-navigation form input[type="search"]:-ms-input-placeholder {
+	#mobile-navigation form input[type=search]:-ms-input-placeholder {
 	color: .rgba( ${responsive_mobile_menu_text_color}, 0.7);
 	}
 	#mobile-navigation ul li a {
@@ -824,13 +824,13 @@ function siteorigin_north_settings_custom_css( $css ) {
 	background: ${branding_accent};
 	border-color: ${branding_accent};
 	}
-	.search-form button[type="submit"],.woocommerce-product-search button[type="submit"] {
+	.search-form button[type=submit],.woocommerce-product-search button[type=submit] {
 	color: ${fonts_text_medium};
 	}
-	.search-form button[type="submit"]:hover,.woocommerce-product-search button[type="submit"]:hover {
+	.search-form button[type=submit]:hover,.woocommerce-product-search button[type=submit]:hover {
 	color: ${fonts_text_dark};
 	}
-	.search-form button[type="submit"] svg path,.woocommerce-product-search button[type="submit"] svg path {
+	.search-form button[type=submit] svg path,.woocommerce-product-search button[type=submit] svg path {
 	fill: ${fonts_text_medium};
 	}
 	.post-pagination {
@@ -916,10 +916,10 @@ function siteorigin_north_wc_settings_custom_css( $css ) {
 	color: ${fonts_text_meta};
 	.font( ${fonts_details} );
 	}
-	.woocommerce #main ul.products li.product h3 {
+	.woocommerce ul.products li.product .woocommerce-loop-product__title a,.woocommerce ul.products li.product h3 {
 	color: ${fonts_text_dark};
 	}
-	.woocommerce #main ul.products li.product .price {
+	.woocommerce ul.products li.product .price {
 	.font( ${fonts_details} );
 	color: ${branding_accent};
 	}
@@ -948,7 +948,7 @@ function siteorigin_north_wc_settings_custom_css( $css ) {
 	background: ${branding_accent};
 	border-color: ${branding_accent};
 	}
-	.woocommerce.single #content div.product .product-under-title-meta {
+	.woocommerce.single #content div.product .product-under-title-meta,.woocommerce.single #content div.product .product_meta {
 	color: ${fonts_text_medium};
 	}
 	.woocommerce.single #content div.product #comments h2 {

--- a/sass/woocommerce/_archives.scss
+++ b/sass/woocommerce/_archives.scss
@@ -100,69 +100,68 @@
 		padding-top: 8px;
 	}
 
-	#main {
-		ul.products {
-			li.product {
-				text-align: center;
+	ul.products {
+		li.product {
+			text-align: center;
 
-				@at-root .wc-columns-2#{&} {
-					margin: 0 5% 2.992em 0;
-					width: 47.5%;
-				}
+			@at-root .wc-columns-2#{&} {
+				margin: 0 5% 2.992em 0;
+				width: 47.5%;
+			}
 
-				@at-root .wc-columns-3#{&} {
-					margin: 0 3.8% 2.992em 0;
-					width: 30.8%;
-				}
+			@at-root .wc-columns-3#{&} {
+				margin: 0 3.8% 2.992em 0;
+				width: 30.8%;
+			}
 
-				@at-root .wc-columns-4#{&} {
-					margin: 0 3.333% 2.992em 0;
-					width: 22.5%;
-				}
+			@at-root .wc-columns-4#{&} {
+				margin: 0 3.333% 2.992em 0;
+				width: 22.5%;
+			}
 
-				@at-root .wc-columns-5#{&} {
-					margin: 0 2.9% 2.992em 0;
-					width: 17.68%;
-				}
+			@at-root .wc-columns-5#{&} {
+				margin: 0 2.9% 2.992em 0;
+				width: 17.68%;
+			}
 
-				@media (max-width: 600px) {
+			@media (max-width: 600px) {
 
-					@at-root body.responsive#{&} {
-						margin-right: 0;
-						width: 100%;
-					}
-				}
-
-				a.added_to_cart {
-					font-size: 13px;
-				}
-
-				&.last {
+				@at-root body.responsive#{&} {
 					margin-right: 0;
+					width: 100%;
 				}
+			}
 
-				.onsale {
-					padding: 0;
-				}
+			a.added_to_cart {
+				font-size: 13px;
+			}
 
-				h3 {
-					color: $color__text_dark;
-					margin-top: 0;
-				}
+			&.last {
+				margin-right: 0;
+			}
 
-				.star-rating {
-					margin: 0 auto 0.5em auto;
-				}
+			.onsale {
+				padding: 0;
+			}
 
-				.price {
-					font-family: $font__detail;
-					color: $color__primary_accent;
-				}
+			.woocommerce-loop-product__title a,
+			h3 {
+				color: $color__text_dark;
+				margin-top: 0;
+			}
 
-				.button {
-					margin-right: 5px;
-					margin-left: 5px;
-				}
+			.star-rating {
+				margin: 0 auto 0.5em auto;
+			}
+
+			.price {
+				font-family: $font__detail;
+				color: $color__primary_accent;
+			}
+
+			.button {
+				margin-right: 5px;
+				margin-left: 5px;
 			}
 		}
 

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -96,39 +96,40 @@
   font-size: 0.85em;
   padding-top: 8px; }
 
-.woocommerce #main ul.products li.product {
+.woocommerce ul.products li.product {
   text-align: center; }
-  .wc-columns-2.woocommerce #main ul.products li.product {
+  .wc-columns-2.woocommerce ul.products li.product {
     margin: 0 5% 2.992em 0;
     width: 47.5%; }
-  .wc-columns-3.woocommerce #main ul.products li.product {
+  .wc-columns-3.woocommerce ul.products li.product {
     margin: 0 3.8% 2.992em 0;
     width: 30.8%; }
-  .wc-columns-4.woocommerce #main ul.products li.product {
+  .wc-columns-4.woocommerce ul.products li.product {
     margin: 0 3.333% 2.992em 0;
     width: 22.5%; }
-  .wc-columns-5.woocommerce #main ul.products li.product {
+  .wc-columns-5.woocommerce ul.products li.product {
     margin: 0 2.9% 2.992em 0;
     width: 17.68%; }
   @media (max-width: 600px) {
-    body.responsive.woocommerce #main ul.products li.product {
+    body.responsive.woocommerce ul.products li.product {
       margin-right: 0;
       width: 100%; } }
-  .woocommerce #main ul.products li.product a.added_to_cart {
+  .woocommerce ul.products li.product a.added_to_cart {
     font-size: 13px; }
-  .woocommerce #main ul.products li.product.last {
+  .woocommerce ul.products li.product.last {
     margin-right: 0; }
-  .woocommerce #main ul.products li.product .onsale {
+  .woocommerce ul.products li.product .onsale {
     padding: 0; }
-  .woocommerce #main ul.products li.product h3 {
+  .woocommerce ul.products li.product .woocommerce-loop-product__title a,
+  .woocommerce ul.products li.product h3 {
     color: #292929;
     margin-top: 0; }
-  .woocommerce #main ul.products li.product .star-rating {
+  .woocommerce ul.products li.product .star-rating {
     margin: 0 auto 0.5em auto; }
-  .woocommerce #main ul.products li.product .price {
+  .woocommerce ul.products li.product .price {
     font-family: "Droid Serif", sans-serif;
     color: #c75d5d; }
-  .woocommerce #main ul.products li.product .button {
+  .woocommerce ul.products li.product .button {
     margin-right: 5px;
     margin-left: 5px; }
 

--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -111,7 +111,7 @@ if ( ! function_exists( 'siteorigin_north_woocommerce_enqueue_scripts' ) ) :
 function siteorigin_north_woocommerce_enqueue_scripts( ){
 	if( !function_exists('is_woocommerce') ) return;
 
-	if( is_woocommerce() ) {
+	if ( is_woocommerce() || wc_post_content_has_shortcode( 'products' ) ) {
 		wp_enqueue_script( 'siteorigin-north-woocommerce', get_template_directory_uri() . '/js/woocommerce.js', array( 'jquery' ), SITEORIGIN_THEME_VERSION );
 		wp_localize_script( 'siteorigin-north-woocommerce', 'so_ajax', array ( 'ajaxurl' => admin_url( 'admin-ajax.php' ) ) );
 	}


### PR DESCRIPTION
To test this PR out, use the WooCommerce shortcode `[products]`. `#main` has been used to allow for archive styling to work on non-WooCommerce pages when the products shortcode is used. When testing, please, ensure that removing #main hasn't impacted specificity to the point that the North styles aren't overriding the default WooCommerce styles.

Building the Customizer CSS updated a few items that aren't part of this PR.