### PR TITLE
WC: Fix Fatal error related to wc_post_content_has_shortcode

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -76,8 +76,9 @@ function siteorigin_north_body_classes( $classes ) {
 			$classes[] = 'equalize-rows';
 		}
 		
-	} if ( wc_post_content_has_shortcode( 'products' ) ) {
-		$classes[] = 'woocommerce';
+		if ( wc_post_content_has_shortcode( 'products' ) ) {
+			$classes[] = 'woocommerce';
+		}
 	}
 
 	elseif ( ! siteorigin_setting( 'masthead_text_above' ) && ! is_active_sidebar( 'topbar-sidebar' ) ) {


### PR DESCRIPTION
This PR will resolve a fatal error if WC isn't enabled.

`Fatal error: Uncaught Error: Call to undefined function wc_post_content_has_shortcode() in /home/cooprestaurang/public_html/wp-content/themes/siteorigin-north/inc/extras.php on line 79`