### PR TITLE
WC: Prevent Sidebar Space when using [products]

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -64,8 +64,12 @@ function siteorigin_north_body_classes( $classes ) {
 			$classes[] = 'layout-wc-sidebar-left';
 		}
 
-		if ( ! is_active_sidebar( 'sidebar-shop' ) && is_woocommerce() || is_cart() || is_checkout() ) {
-			$classes[] = 'no-active-wc-sidebar';
+		if ( ! is_active_sidebar( 'sidebar-shop' ) ) {
+			if ( is_woocommerce() || is_cart() || is_checkout() ) {
+				$classes[] = 'no-active-wc-sidebar';
+			} else {
+				$classes[] = 'active-wc-sidebar';
+			}
 		}
 		
 		if ( siteorigin_setting( 'woocommerce_sidebar_position' ) == 'none' && ( is_woocommerce() || is_cart() || is_checkout() ) ) {

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -67,8 +67,6 @@ function siteorigin_north_body_classes( $classes ) {
 		if ( ! is_active_sidebar( 'sidebar-shop' ) ) {
 			if ( is_woocommerce() || is_cart() || is_checkout() ) {
 				$classes[] = 'no-active-wc-sidebar';
-			} else {
-				$classes[] = 'active-wc-sidebar';
 			}
 		}
 		

--- a/sass/layout/_content-sidebar.scss
+++ b/sass/layout/_content-sidebar.scss
@@ -26,6 +26,7 @@
 }
 
 .no-active-sidebar:not(.woocommerce):not(.woocommerce-page),
+.no-active-sidebar:not(.active-wc-sidebar),
 .no-active-sidebar.no-active-wc-sidebar,
 .wc-sidebar-none.woocommerce.woocommerce-page {
 

--- a/style.css
+++ b/style.css
@@ -1239,6 +1239,7 @@ a {
     min-width: 0; }
 
 .no-active-sidebar:not(.woocommerce):not(.woocommerce-page) .content-area,
+.no-active-sidebar:not(.active-wc-sidebar) .content-area,
 .no-active-sidebar.no-active-wc-sidebar .content-area,
 .wc-sidebar-none.woocommerce.woocommerce-page .content-area {
   float: none;
@@ -1246,6 +1247,7 @@ a {
   width: auto; }
 
 .no-active-sidebar:not(.woocommerce):not(.woocommerce-page) .site-main,
+.no-active-sidebar:not(.active-wc-sidebar) .site-main,
 .no-active-sidebar.no-active-wc-sidebar .site-main,
 .wc-sidebar-none.woocommerce.woocommerce-page .site-main {
   margin: 0; }


### PR DESCRIPTION
Resolve https://github.com/siteorigin/siteorigin-north/issues/415

To test:
- Remove all widgets in all sidebars.
- Add products shortcode to page.

Sidebar space will be present before PR, and removed after PR.