### PR TITLE
Enable FitVids if Enabled in Theme Settings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -272,6 +272,7 @@ function siteorigin_north_scripts() {
 		'smoothScroll' => siteorigin_setting( 'navigation_smooth_scroll' ),
 		'logoScale' => is_numeric( $logo_sticky_scale ) ? $logo_sticky_scale : 0.755,
 		'collapse' => siteorigin_setting( 'responsive_menu_breakpoint' ),
+		'fitvids' => siteorigin_setting( 'responsive_fitvids' ),
 	) );
 
 	// Comment reply.

--- a/functions.php
+++ b/functions.php
@@ -266,7 +266,7 @@ function siteorigin_north_scripts() {
 	// Skip link focus fix.
 	wp_enqueue_script( 'siteorigin-north-skip-link', get_template_directory_uri() . '/js/skip-link-focus-fix' . SITEORIGIN_THEME_JS_PREFIX . '.js', array(), SITEORIGIN_THEME_VERSION, true );
 
-	// Localize smooth scroll and output sticky logo scale.
+	// Add settings variables used by main theme JS.
 	$logo_sticky_scale = apply_filters( 'siteorigin_north_logo_sticky_scale', 0.755 );
 	wp_localize_script( 'siteorigin-north-script', 'siteoriginNorth', array(
 		'smoothScroll' => siteorigin_setting( 'navigation_smooth_scroll' ),

--- a/js/north.js
+++ b/js/north.js
@@ -109,7 +109,7 @@
 	} );
 
 	// Setup FitVids for entry content, panels and WooCommerce. Ignore Tableau.
-	if ( typeof $.fn.fitVids !== 'undefined' ) {
+	if ( typeof $.fn.fitVids !== 'undefined' && siteoriginNorth.fitvids ) {
 		$( '.entry-content, .entry-content .panel, .woocommerce #main' ).fitVids( { ignore: '.tableauViz' } );
 	}
 


### PR DESCRIPTION
North version of https://github.com/siteorigin/vantage/pull/391

Same test instructions except you're looking for:

`$( '.entry-content, .entry-content .panel, .woocommerce #main' ).fitVids( { ignore: '.tableauViz' } );`