### PR TITLE
Scroll to Top: Use Alternative Offset When Header is Disabled

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -259,15 +259,14 @@
 	// The scroll to top button.
 	var sttWindowScroll = function() {
 		var top = window.pageYOffset || document.documentElement.scrollTop;
+		var scrollOffset = $( '#masthead' ).length ? $( '#masthead' ).outerHeight() : $( window ).outerHeight() / 2;
 
-		if ( top > $( '#masthead' ).outerHeight() ) {
+		if ( top > scrollOffset ) {
 			if ( ! $( '#scroll-to-top' ).hasClass( 'show' ) ) {
 				$( '#scroll-to-top' ).css( 'pointer-events', 'auto' ).addClass( 'show' );
 			}
-		} else {
-			if ( $( '#scroll-to-top' ).hasClass( 'show' ) ) {
-				$( '#scroll-to-top' ).css( 'pointer-events', 'none' ).removeClass( 'show' );
-			}
+		} else if ( $( '#scroll-to-top' ).hasClass( 'show' ) ) {
+			$( '#scroll-to-top' ).css( 'pointer-events', 'none' ).removeClass( 'show' );
 		}
 	};
 


### PR DESCRIPTION
This PR allows for Scroll to Top to work when there isn't a header present. It does this by offsetting by half a screen length (which is roughly what the offset would have been) instead. To test this PR:

- Enable scroll to top
- Setup a page that's long enough to show scroll to top.
- Disable the header.

Prior to this PR, you'll note that the scroll to top never appears while the header is disabled. After this PR you'll notice that it works as expected - although when it appears may change depending upon the size of your header relative to your screen size.