### PR TITLE
Page Settings: Correct Post Type Check

### DIFF
--- a/inc/settings.php
+++ b/inc/settings.php
@@ -1315,8 +1315,7 @@ function siteorigin_north_page_settings( $settings, $type, $id ){
 		'description'    => __( 'Display the page title on this page.', 'siteorigin-north' )
 	);
 
-	if ( $type == 'post' ) $post = get_post( $id );
-	if ( ! empty( $post ) && $post->post_type == 'page' ) {
+	if ( $type == 'page' ) {
 		$settings['featured_image'] = array(
 			'type'           => 'checkbox',
 			'label'          => __( 'Page Featured Image', 'siteorigin-north' ),
@@ -1371,8 +1370,7 @@ function siteorigin_north_setup_page_setting_defaults( $defaults, $type, $id ) {
 	$defaults['hide_footer_widgets'] = false;
 
 	// Defaults for page only settings.
-	if( $type == 'post' ) $post = get_post( $id );
-	if( ! empty( $post ) && $post->post_type == 'page' ) {
+	if ( $type == 'page' ) {
 		$defaults['featured_image'] = false;
 	}
 


### PR DESCRIPTION
This issue will restore the Page Featured Image setting. This issue occurred due to the recent settings framework change that resulted in the correct post type being passed rather than just `post` all of the time.