### PR TITLE
WooCommerce Shop Sidebar: Prevent shop sidebar appearing after content on archives

### DIFF
--- a/inc/extras.php
+++ b/inc/extras.php
@@ -64,8 +64,10 @@ function siteorigin_north_body_classes( $classes ) {
 			$classes[] = 'layout-wc-sidebar-left';
 		}
 
-		if ( ! is_active_sidebar( 'sidebar-shop' ) ) {
-			if ( is_woocommerce() || is_cart() || is_checkout() ) {
+		if ( is_woocommerce() || is_cart() || is_checkout() ) {
+			if ( is_active_sidebar( 'sidebar-shop' ) ) {
+				$classes[] = 'active-wc-sidebar';
+			} else {
 				$classes[] = 'no-active-wc-sidebar';
 			}
 		}


### PR DESCRIPTION
To test this PR please add a widget to the Shop Sidebar and remove all widgets in the sidebar widget area. This will result in the widgets appearing below the content area. Upon switching to this PR, the sidebar will appear in the expected location.