### PR TITLE
Fix undefined variable $woocommerce in functions.php

### DIFF
--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -180,6 +180,8 @@ function siteorigin_north_woocommerce_update_cart_count( $fragments ) {
 	return $fragments;
 }
 endif;
+
+global $woocommerce;
 if ( version_compare( $woocommerce->version, '3', '<' ) ) {
 	add_filter( 'add_to_cart_fragments', 'siteorigin_north_woocommerce_update_cart_count' );
 } else {


### PR DESCRIPTION
Missing global to access a global variable raises a warning (tested with PHP 8)