### PR TITLE
Flexslider: Remove Unused Font Inclusion

### DIFF
--- a/css/flexslider.css
+++ b/css/flexslider.css
@@ -10,16 +10,6 @@
  *
  */
 /* ====================================================================================================================
- * FONT-FACE
- * ====================================================================================================================*/
-@font-face {
-  font-family: 'flexslider-icon';
-  src: url('fonts/flexslider-icon.eot');
-  src: url('fonts/flexslider-icon.eot?#iefix') format('embedded-opentype'), url('fonts/flexslider-icon.woff') format('woff'), url('fonts/flexslider-icon.ttf') format('truetype'), url('fonts/flexslider-icon.svg#flexslider-icon') format('svg');
-  font-weight: normal;
-  font-style: normal;
-}
-/* ====================================================================================================================
  * RESETS
  * ====================================================================================================================*/
 .flex-container a:hover,


### PR DESCRIPTION
We add the icons using SVG rather than the default font faces - those aren't present anywhere.

https://github.com/siteorigin/siteorigin-north/blob/50eb543fe53173e216a5e3e2393f43b509ce25fc/style.css#L1714-L1725