### PR TITLE
WC: Fix Add to Cart Button Output & Resolve Error

### DIFF
--- a/woocommerce/functions.php
+++ b/woocommerce/functions.php
@@ -377,11 +377,11 @@ if ( ! function_exists( 'siteorigin_north_wc_cart_wrapper_close' ) ) {
 }
 add_action( 'woocommerce_after_cart_table', 'siteorigin_north_wc_cart_wrapper_close' );
 
-function siteorigin_settings_override_add_to_cart_btn( $btn, $product, $args = [] ) {
-	$args = wp_parse_args( $args, [
+function siteorigin_settings_override_add_to_cart_btn( $btn, $product, $args = array() ) {
+	$args = wp_parse_args( $args, array(
 		'quantity' => 1,
 		'class' => 'button'
-	] );
+	) );
 
 	$new_btn = sprintf(
 		'<a rel="nofollow" href="%s" data-quantity="%s" data-product_id="%s" data-product_sku="%s" class="%s"><span class="north-icon-cart" aria-hidden="true"></span> %s</a>',
@@ -389,7 +389,7 @@ function siteorigin_settings_override_add_to_cart_btn( $btn, $product, $args = [
 		esc_attr( $args['quantity'] ),
 		esc_attr( $product->get_id()),
 		esc_attr( $product->get_sku() ),
-		esc_attr( $args['class ']),
+		esc_attr( $args['class'] ),
 		esc_html( $product->add_to_cart_text() )
 	);
 


### PR DESCRIPTION
Resolves the below error, and output of the button.:

` PHP Warning:  Undefined array key "class " woocommerce/functions.php on line 392`