### PR TITLE
Add `siteorigin_north_sticky_topbar`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -312,6 +312,7 @@ if ( ! function_exists( 'siteorigin_north_scripts' ) ) {
 
 		// Add settings variables used by main theme JS.
 		$logo_sticky_scale = apply_filters( 'siteorigin_north_logo_sticky_scale', 0.755 );
+		$sticky_topbar = apply_filters( 'siteorigin_north_sticky_topbar', false );
 		wp_localize_script(
 			'siteorigin-north-script',
 			'siteoriginNorth',
@@ -320,6 +321,7 @@ if ( ! function_exists( 'siteorigin_north_scripts' ) ) {
 				'logoScale' => is_numeric( $logo_sticky_scale ) ? $logo_sticky_scale : 0.755,
 				'collapse' => siteorigin_setting( 'responsive_menu_breakpoint' ),
 				'fitvids' => siteorigin_setting( 'responsive_fitvids' ),
+				'stickyTopbar' => $sticky_topbar,
 			)
 		);
 

--- a/js/north.js
+++ b/js/north.js
@@ -471,7 +471,7 @@
 				}
 			}
 
-			if ( whenToStickyMh() === 0 ) {
+			if ( whenToStickyMh() === 0 || ! siteoriginNorth.stickyTopbar ) {
 				smSetup();
 				$( window ).on( 'resize scroll', smSetup );
 			} else {

--- a/js/north.js
+++ b/js/north.js
@@ -124,7 +124,7 @@
 			$( this ).on( 'click touchend', function( e ) {
 				var link = $( this );
 				e.stopPropagation();
-				
+
 				if ( e.type == 'click' ) {
 					return;
 				}
@@ -402,14 +402,22 @@
 				$tb = $( '#topbar' ),
 				$wpab = $( '#wpadminbar' );
 
-			// Sticky header shadow.
-			var smShadow = function() {
-				if ( $( window ).scrollTop() > 0 ) {
-					$( $mh ).addClass( 'floating' );
-				} else {
-					$( $mh ).removeClass( 'floating' );
-				}
-			};
+				const whenToStickyMh = function() {
+					const wpabMobile = $( window ).width() <= 600;
+					const wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
+					const tbHeight = $tb.length && siteoriginNorth.stickyTopbar ? $tb.outerHeight() : 0;
+
+					return wpabHeight + tbHeight;
+				};
+
+				// Sticky header shadow.
+				var smShadow = function() {
+					if ( $( window ).scrollTop() > whenToStickyMh ) {
+						$( $mh ).addClass( 'floating' );
+					} else {
+						$( $mh ).removeClass( 'floating' );
+					}
+				};
 			smShadow();
 			$( window ).on( 'scroll', smShadow );
 
@@ -430,7 +438,13 @@
 					$( 'body' ).removeClass( 'topbar-out' );
 				}
 
-				if ( $( 'body' ).hasClass( 'no-topbar' ) || ( ! $( 'body' ).hasClass( 'no-topbar' ) &&  $( 'body' ).hasClass( 'topbar-out' ) ) ) {
+				if (
+					$( 'body' ).hasClass( 'no-topbar' ) ||
+					(
+						! $( 'body' ).hasClass( 'no-topbar' ) &&
+						$( 'body' ).hasClass( 'topbar-out' )
+					)
+				) {
 					$mh.css( 'position', 'fixed' );
 				} else if ( ! $( 'body' ).hasClass( 'no-topbar' ) &&  ! $( 'body' ).hasClass( 'topbar-out' ) ) {
 					$mh.css( 'position', 'absolute' );
@@ -455,9 +469,27 @@
 					$mh.removeClass( 'mobile-sticky-menu' );
 				}
 			}
-			
-			smSetup();
-			$( window ).on( 'resize scroll', smSetup );
+
+			if ( whenToStickyMh() === 0 ) {
+				smSetup();
+				$( window ).on( 'resize scroll', smSetup );
+			} else {
+				const tbMhStickyPosition = function() {
+					const wpabMobile = $( window ).width() <= 600;
+					$tb.css( {
+						'position': 'sticky',
+						'top': $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0,
+					} );
+
+					$mh.css( {
+						'position': 'sticky',
+						'top': whenToStickyMh(),
+					} );
+				};
+
+				tbMhStickyPosition();
+				$( window ).on( 'resize', tbMhStickyPosition );
+			}
 		}
 
 		// Adjust for sticky header when linking from external anchors.

--- a/js/north.js
+++ b/js/north.js
@@ -402,22 +402,23 @@
 				$tb = $( '#topbar' ),
 				$wpab = $( '#wpadminbar' );
 
-				const whenToStickyMh = function() {
-					const wpabMobile = $( window ).width() <= 600;
-					const wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
-					const tbHeight = $tb.length && siteoriginNorth.stickyTopbar ? $tb.outerHeight() : 0;
+			var whenToStickyMh = function() {
+				var wpabMobile = $( window ).width() <= 600;
+				var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
+				var tbHeight = $tb.length && siteoriginNorth.stickyTopbar ? $tb.outerHeight() : 0;
 
-					return wpabHeight + tbHeight;
-				};
+				return wpabHeight + tbHeight;
+			};
 
-				// Sticky header shadow.
-				var smShadow = function() {
-					if ( $( window ).scrollTop() > whenToStickyMh ) {
-						$( $mh ).addClass( 'floating' );
-					} else {
-						$( $mh ).removeClass( 'floating' );
-					}
-				};
+			// Sticky header shadow.
+			var smShadow = function() {
+				if ( $( window ).scrollTop() > whenToStickyMh ) {
+					$( $mh ).addClass( 'floating' );
+				} else {
+					$( $mh ).removeClass( 'floating' );
+				}
+			};
+
 			smShadow();
 			$( window ).on( 'scroll', smShadow );
 
@@ -474,8 +475,8 @@
 				smSetup();
 				$( window ).on( 'resize scroll', smSetup );
 			} else {
-				const tbMhStickyPosition = function() {
-					const wpabMobile = $( window ).width() <= 600;
+				var tbMhStickyPosition = function() {
+					var wpabMobile = $( window ).width() <= 600;
 					$tb.css( {
 						'position': 'sticky',
 						'top': $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0,


### PR DESCRIPTION
This PR allows for the top bar to be sticky in addition to the masthead. It's currently enabled using the following filter:

`add_filter( 'siteorigin_north_sticky_topbar', '__return_true' );`