### PR TITLE
WC: Update Pagination Version

### DIFF
--- a/woocommerce/loop/pagination.php
+++ b/woocommerce/loop/pagination.php
@@ -4,7 +4,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  *
- * @version 3.3.1
+ * @version 9.3.0
  */
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly


### PR DESCRIPTION
No Changed Required outside of the version bump

`siteorigin-north/woocommerce/loop/pagination.php version 3.3.1 is out of date. The core version is 9.3.0,`