### PR TITLE
Logo booster fixes

### DIFF
--- a/js/north.js
+++ b/js/north.js
@@ -412,15 +412,14 @@
 
 			// Sticky header shadow.
 			var smShadow = function() {
-				if ( $( window ).scrollTop() > whenToStickyMh ) {
+				if ( $( window ).scrollTop() > whenToStickyMh() ) {
 					$( $mh ).addClass( 'floating' );
 				} else {
 					$( $mh ).removeClass( 'floating' );
 				}
 			};
 
-			smShadow();
-			$( window ).on( 'scroll', smShadow );
+			$( window ).on( 'scroll', smShadow ).trigger( 'scroll' );
 
 			var smSetup = function() {
 

--- a/sass/site/primary/_masthead.scss
+++ b/sass/site/primary/_masthead.scss
@@ -99,7 +99,7 @@
 		}
 
 		@at-root #masthead.floating img.alt-logo-scroll {
-			display: block;
+			display: inline-block;
 		}
 	}
 

--- a/style.css
+++ b/style.css
@@ -1429,7 +1429,7 @@ body.page-layout-stripped #main.site-main {
     #masthead .site-branding img.alt-logo-scroll {
       display: none; }
     #masthead.floating img.alt-logo-scroll {
-      display: block; }
+      display: inline-block; }
   #masthead .site-branding,
   #masthead .main-navigation {
     display: table-cell;


### PR DESCRIPTION
This PR will restore the `.floating` class to be added to the Masthead after scroll, and resolve an alignment issue with the sticky logo.