### PR TITLE
Fix/Menu Overlap Setting

### DIFF
--- a/inc/settings.conf.php
+++ b/inc/settings.conf.php
@@ -30,6 +30,7 @@ return array(
 		'masthead_background_color' => 'masthead__background_color',
 		'masthead_background_overlap_opacity' => 'masthead__background_overlap_opacity',
 		'masthead_top_background_color' => 'masthead__top_background_color',
+		'masthead_top_background_overlap_opacity' => 'masthead__top_background_overlap_opacity',
 		'masthead_border_color' => 'masthead__border_color',
 		'masthead_border_width' => 'masthead__border_width',
 		'masthead_padding' => 'masthead__padding',

--- a/inc/settings.conf.php
+++ b/inc/settings.conf.php
@@ -28,6 +28,7 @@ return array(
 
 		// Header.
 		'masthead_background_color' => 'masthead__background_color',
+		'masthead_background_overlap_opacity' => 'masthead__background_overlap_opacity',
 		'masthead_top_background_color' => 'masthead__top_background_color',
 		'masthead_border_color' => 'masthead__border_color',
 		'masthead_border_width' => 'masthead__border_width',

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -173,33 +173,12 @@ function siteorigin_north_settings_init() {
 		'masthead'    => array(
 			'title'  => __( 'Header', 'siteorigin-north' ),
 			'fields' => array(
-				'layout'               => array(
-					'type'    => 'select',
-					'label'   => __( 'Header layout', 'siteorigin-north' ),
-					'options' => array(
-						'default'  => __( 'Default', 'siteorigin-north' ),
-						'centered' => __( 'Centered', 'siteorigin-north' ),
-					),
-				),
+				// Top Bar Settings
 				'text_above'           => array(
 					'type'              => 'text',
 					'label'             => __( 'Text Above', 'siteorigin-north' ),
 					'description'       => __( 'Text that goes above the main header.', 'siteorigin-north' ),
 					'sanitize_callback' => 'wp_kses_post',
-				),
-				'background_color'     => array(
-					'type'  => 'color',
-					'label' => __( 'Background Color', 'siteorigin-north' ),
-					'live'  => true,
-				),
-				'background_overlap_opacity' => array(
-					'type'        => 'range',
-					'label'       => __( 'Background Color Overlap Opacity', 'siteorigin-north' ),
-					'description' => __( 'Background opacity when header overlaps content.', 'siteorigin-north' ),
-					'min'         => 0,
-					'max'         => 1,
-					'step'        => 0.01,
-					'live'        => true,
 				),
 				'top_background_color' => array(
 					'type'  => 'color',
@@ -210,6 +189,34 @@ function siteorigin_north_settings_init() {
 					'type'        => 'range',
 					'label'       => __( 'Background Top Color Overlap Opacity', 'siteorigin-north' ),
 					'description' => __( 'Top bar background opacity when header overlaps content.', 'siteorigin-north' ),
+					'min'         => 0,
+					'max'         => 1,
+					'step'        => 0.01,
+					'live'        => true,
+				),
+				'top_padding'          => array(
+					'type'              => 'measurement',
+					'label'             => __( 'Top Bar Widgets Padding', 'siteorigin-north' ),
+					'live'              => false,
+				),
+				// Header Settings
+				'layout'               => array(
+					'type'    => 'select',
+					'label'   => __( 'Header layout', 'siteorigin-north' ),
+					'options' => array(
+						'default'  => __( 'Default', 'siteorigin-north' ),
+						'centered' => __( 'Centered', 'siteorigin-north' ),
+					),
+				),
+				'background_color'     => array(
+					'type'  => 'color',
+					'label' => __( 'Background Color', 'siteorigin-north' ),
+					'live'  => true,
+				),
+				'background_overlap_opacity' => array(
+					'type'        => 'range',
+					'label'       => __( 'Background Color Overlap Opacity', 'siteorigin-north' ),
+					'description' => __( 'Background opacity when header overlaps content.', 'siteorigin-north' ),
 					'min'         => 0,
 					'max'         => 1,
 					'step'        => 0.01,
@@ -228,11 +235,6 @@ function siteorigin_north_settings_init() {
 				'padding'              => array(
 					'type'              => 'measurement',
 					'label'             => __( 'Padding', 'siteorigin-north' ),
-					'live'              => false,
-				),
-				'top_padding'          => array(
-					'type'              => 'measurement',
-					'label'             => __( 'Top Bar Widgets Padding', 'siteorigin-north' ),
 					'live'              => false,
 				),
 				'bottom_margin'        => array(

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -192,6 +192,15 @@ function siteorigin_north_settings_init() {
 					'label' => __( 'Background Color', 'siteorigin-north' ),
 					'live'  => true,
 				),
+				'background_overlap_opacity' => array(
+					'type'        => 'range',
+					'label'       => __( 'Background Color Overlap Opacity', 'siteorigin-north' ),
+					'description' => __( 'Background opacity when header overlaps content.', 'siteorigin-north' ),
+					'min'         => 0,
+					'max'         => 1,
+					'step'        => 0.01,
+					'live'        => true,
+				),
 				'top_background_color' => array(
 					'type'  => 'color',
 					'label' => __( 'Background Top Color', 'siteorigin-north' ),
@@ -877,6 +886,9 @@ function siteorigin_north_settings_custom_css( $css ) {
 	}
 	#commentform input,#commentform textarea {
 	background-color: ${fonts_field_background};
+	}
+	.page-layout-menu-overlap #masthead:not(.floating) {
+	background: .rgba( ${masthead_background_color}, ${masthead_background_overlap_opacity});
 	}';
 
 	return $css;
@@ -1201,6 +1213,7 @@ function siteorigin_north_settings_defaults( $defaults ) {
 	$defaults['masthead_layout']                           = 'default';
 	$defaults['masthead_text_above']                       = '';
 	$defaults['masthead_background_color']                 = '#fafafa';
+	$defaults['masthead_background_overlap_opacity']       = '0.975';
 	$defaults['masthead_top_background_color']             = '#f4f4f4';
 	$defaults['masthead_border_color']                     = '#d4d4d4';
 	$defaults['masthead_border_width']                     = '1px';

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -945,11 +945,13 @@ function siteorigin_north_wc_settings_custom_css( $css ) {
 	.font( ${fonts_details} );
 	color: ${branding_accent};
 	}
-	.woocommerce button.button.alt,.woocommerce #review_form #respond .form-submit input,.woocommerce .woocommerce-message .button,.woocommerce .products .button {
-	color: ${fonts_text_dark};
-	.font( ${fonts_headings} );
+	.woocommerce button.button.alt,.woocommerce #review_form #respond .form-submit input,.woocommerce .woocommerce-message .button,.woocommerce .products
+	.button {
+		color: ${fonts_text_dark};
+		.font( ${fonts_headings} );
 	}
-	.woocommerce button.button.alt:hover,.woocommerce #review_form #respond .form-submit input:hover,.woocommerce .woocommerce-message .button:hover,.woocommerce .products .button:hover {
+	.woocommerce button.button.alt:hover,.woocommerce #review_form #respond .form-submit input:hover,.woocommerce .woocommerce-message
+	.button:hover,.woocommerce .products .button:hover {
 	background: ${branding_accent_dark};
 	border-color: ${branding_accent_dark};
 	}
@@ -999,8 +1001,7 @@ function siteorigin_north_wc_settings_custom_css( $css ) {
 	border: 1px solid ${fonts_text_dark};
 	color: ${fonts_text_dark};
 	}
-	.woocommerce table.shop_table .button.checkout-button,
-	.woocommerce .so-panel .wc-proceed-to-checkout .checkout-button.button {
+	.woocommerce table.shop_table .button.checkout-button {
 	background: ${branding_accent};
 	border: 1px solid ${branding_accent};
 	}

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -206,6 +206,15 @@ function siteorigin_north_settings_init() {
 					'label' => __( 'Background Top Color', 'siteorigin-north' ),
 					'live'  => true,
 				),
+				'top_background_overlap_opacity' => array(
+					'type'        => 'range',
+					'label'       => __( 'Background Top Color Overlap Opacity', 'siteorigin-north' ),
+					'description' => __( 'Top bar background opacity when header overlaps content.', 'siteorigin-north' ),
+					'min'         => 0,
+					'max'         => 1,
+					'step'        => 0.01,
+					'live'        => true,
+				),
 				'border_color'         => array(
 					'type'  => 'color',
 					'label' => __( 'Border Color', 'siteorigin-north' ),
@@ -889,6 +898,9 @@ function siteorigin_north_settings_custom_css( $css ) {
 	}
 	.page-layout-menu-overlap #masthead:not(.floating) {
 	background: .rgba( ${masthead_background_color}, ${masthead_background_overlap_opacity});
+	}
+	.page-layout-menu-overlap #topbar:not(.floating) {
+	background: .rgba( ${masthead_top_background_color}, ${masthead_top_background_overlap_opacity});
 	}';
 
 	return $css;
@@ -1215,6 +1227,7 @@ function siteorigin_north_settings_defaults( $defaults ) {
 	$defaults['masthead_background_color']                 = '#fafafa';
 	$defaults['masthead_background_overlap_opacity']       = '0.975';
 	$defaults['masthead_top_background_color']             = '#f4f4f4';
+	$defaults['masthead_top_background_overlap_opacity']   = '0.975';
 	$defaults['masthead_border_color']                     = '#d4d4d4';
 	$defaults['masthead_border_width']                     = '1px';
 	$defaults['masthead_padding']                          = '30px';

--- a/js/north.js
+++ b/js/north.js
@@ -477,7 +477,7 @@
 						// Threshold is when we've scrolled past where the top bar ends.
 						stickyThreshold = $tb.outerHeight() + adminBarOffset - 1;
 					} else {
-						// Without top bar, use zero threshold for seamless sticky behavior.
+						// Without top bar, add shadow immediately when scrolling starts.
 						stickyThreshold = 0;
 					}
 				} else {

--- a/js/north.js
+++ b/js/north.js
@@ -372,6 +372,37 @@
 		var scrollOnLoad = true;
 	}
 
+	/**
+	 * Adjusts the top position of the masthead based on the top bar's position and visibility.
+	 *
+	 * @param {number} pageY - The current Y position of the page (scroll position).
+	 * @param {number} adminBarOffset - The height of the admin bar, if present.
+	 * @param {jQuery} $tb - The jQuery object representing the top bar element.
+	 * @param {boolean} [topBarHidden=false] - Whether the top bar is hidden or not.
+	 *
+	 * @returns {number} - The calculated top position for the masthead.
+	 */
+	const adjustMastheadTop = function(
+		pageY,
+		adminBarOffset,
+		$tb,
+		topBarHidden = false,
+	) {
+		if (topBarHidden) {
+			return adminBarOffset;
+		}
+
+		// Calculate the Y end position of the top bar relative to the page
+		var tbEndY = $tb.length ?
+			$tb.offset().top + $tb.outerHeight() - pageY :
+			0;
+
+		return Math.max(
+			adminBarOffset,
+			tbEndY
+		);
+	};
+
 	// Handle menu overlap positioning on DOMContentLoaded for CLS prevention.
 	$( document ).ready( function() {
 		if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
@@ -541,26 +572,28 @@
 				if ( ! $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
 					$mhs.css( 'height', $mh.outerHeight() );
 				}
-				// Toggle .topbar-out with visibility of top-bar in the viewport.
-				if ( ! $( 'body' ).hasClass( 'no-topbar' ) && ! $tb.northIsVisible() ) {
-					$( 'body' ).addClass( 'topbar-out' );
-				}
-				if ( $tb.length && $( 'body' ).hasClass( 'topbar-out' ) && $tb.northIsVisible() ) {
-					$( 'body' ).removeClass( 'topbar-out' );
-				}
-				
+
 				const adminBarOffset = getAdminBarOffset( $wpab );
+
+				var topBarHidden = false;
+				if ( $tb.length ) {
+					topBarHidden = ! $tb.northIsVisible( adminBarOffset );
+
+					$( 'body' ).toggleClass( 'no-topbar',
+						topBarHidden
+					);
+				}
 
 				// Handle positioning based on overlap and sticky combination.
 				if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
 					// BOTH sticky and overlap are enabled.
 					var scrollTop = $( window ).scrollTop();
+					var tbHeight = $tb.outerHeight();
 
 					// Initial overlap state with absolute positioning.
 					if ( scrollTop <= 0 ) {
 						// Set topbar position when present.
 						if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
-							var tbHeight = $tb.outerHeight();
 							$tb.css( {
 								'position': 'absolute',
 								'top': adminBarOffset + 'px',
@@ -582,19 +615,23 @@
 						}
 					} else {
 						// Header transitions to fixed positioning while topbar remains absolute.
-						var stickyTop = adminBarOffset;
-						
+
 						// Remove admin bar offset on mobile when admin bar not visible.
 						if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
 							if ( ! $wpab.northIsVisible() ) {
 								stickyTop = 0;
 							}
 						}
-						
+
 						// Apply fixed positioning to header.
 						$mh.css( {
 							'position': 'fixed',
-							'top': stickyTop + 'px'
+							'top': adjustMastheadTop(
+								scrollTop,
+								adminBarOffset,
+								$tb,
+								topBarHidden
+							) + 'px',
 						} );
 					}
 				} else {
@@ -603,7 +640,7 @@
 						$( 'body' ).hasClass( 'no-topbar' ) ||
 						(
 							! $( 'body' ).hasClass( 'no-topbar' ) &&
-							$( 'body' ).hasClass( 'topbar-out' )
+							topBarHidden
 						)
 					) {
 						$mh.css( 'position', 'fixed' );

--- a/js/north.js
+++ b/js/north.js
@@ -528,31 +528,7 @@
 			// Sticky header shadow.
 			var smShadow = function() {
 				var scrollTop = $( window ).scrollTop();
-				var stickyThreshold;
-
-				if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
-					// For overlap pages, calculate threshold based on top bar presence.
-					if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
-						// When top bar exists, header becomes sticky after scrolling past the top bar.
-						var wpabMobile = $( window ).width() <= 600;
-						var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
-						var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
-
-						// Mobile admin bar requires different offset height.
-						if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
-							adminBarOffset = $wpab.length ? 46 : 0;
-						}
-
-						// Threshold is when we've scrolled past where the top bar ends.
-						stickyThreshold = $tb.outerHeight() + adminBarOffset - 1;
-					} else {
-						// Without top bar, add shadow immediately when scrolling starts.
-						stickyThreshold = 0;
-					}
-				} else {
-					// Non-overlap pages use the standard calculation.
-					stickyThreshold = whenToStickyMh();
-				}
+				var stickyThreshold = whenToStickyMh();
 
 				if ( scrollTop > stickyThreshold ) {
 					$( $mh ).addClass( 'floating' );

--- a/js/north.js
+++ b/js/north.js
@@ -395,6 +395,49 @@
 			$( window ).on( 'scroll resize', smResizeLogo );
 		}
 
+		// Handle menu overlap positioning independent of sticky menu setting.
+		if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) && ! $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
+			// Menu overlap WITHOUT sticky menu.
+			var $mh = $( '#masthead' ),
+				$tb = $( '#topbar' ),
+				$wpab = $( '#wpadminbar' );
+
+			var overlapPositioning = function() {
+				var wpabMobile = $( window ).width() <= 600;
+				var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
+				var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
+
+				// Mobile admin bar requires different offset height.
+				if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
+					adminBarOffset = $wpab.length ? 46 : 0;
+				}
+
+				// Set topbar position when present.
+				if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
+					var tbHeight = $tb.outerHeight();
+					$tb.css( {
+						'position': 'absolute',
+						'top': adminBarOffset + 'px'
+					} );
+					// Header positioned below topbar to maintain visual hierarchy.
+					$mh.css( {
+						'position': 'absolute',
+						'top': ( adminBarOffset + tbHeight ) + 'px'
+					} );
+				} else {
+					// Header positioned at admin bar offset when topbar absent.
+					$mh.css( {
+						'position': 'absolute',
+						'top': adminBarOffset + 'px'
+					} );
+				}
+			};
+
+			// Run on load and resize.
+			overlapPositioning();
+			$( window ).on( 'resize', overlapPositioning );
+		}
+
 		// Now lets do the sticky menu.
 		if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
 			var $mh = $( '#masthead' ),
@@ -441,47 +484,59 @@
 					$( 'body' ).removeClass( 'topbar-out' );
 				}
 
-				// Handle hybrid positioning for menu overlap + sticky combination
+				// Handle positioning based on overlap and sticky combination.
 				if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
+					// BOTH sticky and overlap are enabled.
 					var scrollTop = $( window ).scrollTop();
 					var wpabMobile = $( window ).width() <= 600;
 					var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
-					var tbHeight = $tb.length && siteoriginNorth.stickyTopbar ? $tb.outerHeight() : 0;
 					var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
 					
-					// On mobile with admin bar, use mobile-specific offset
+					// Mobile admin bar requires different offset height.
 					if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
-						adminBarOffset = $wpab.length ? 46 : 0; // Mobile admin bar height
+						adminBarOffset = $wpab.length ? 46 : 0;
 					}
 
-					// Start with absolute positioning (overlap effect with transparency)
+					// Initial overlap state with absolute positioning.
 					if ( scrollTop <= 10 ) {
-						$mh.css( {
-							'position': 'absolute',
-							'top': adminBarOffset + 'px'
-						} );
+						// Set topbar position when present.
+						if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
+							var tbHeight = $tb.outerHeight();
+							$tb.css( {
+								'position': 'absolute',
+								'top': adminBarOffset + 'px'
+							} );
+							// Header positioned below topbar to maintain visual hierarchy.
+							$mh.css( {
+								'position': 'absolute',
+								'top': ( adminBarOffset + tbHeight ) + 'px'
+							} );
+						} else {
+							// Header positioned at admin bar offset when topbar absent.
+							$mh.css( {
+								'position': 'absolute',
+								'top': adminBarOffset + 'px'
+							} );
+						}
 					} else {
-						// Transition to fixed positioning (sticky effect, remove transparency)
-						var topPosition = adminBarOffset;
+						// Header transitions to fixed positioning while topbar remains absolute.
+						var stickyTop = adminBarOffset;
 						
-						// On mobile, don't offset for admin bar when scrolled (like mobile-sticky-menu)
+						// Remove admin bar offset on mobile when admin bar not visible.
 						if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
 							if ( ! $wpab.northIsVisible() ) {
-								topPosition = 0; // No admin bar offset when scrolled on mobile
+								stickyTop = 0;
 							}
 						}
 						
-						if ( $tb.length && siteoriginNorth.stickyTopbar && $( 'body' ).hasClass( 'topbar-out' ) ) {
-							topPosition += tbHeight;
-						}
-						
+						// Apply fixed positioning to header.
 						$mh.css( {
 							'position': 'fixed',
-							'top': topPosition + 'px'
+							'top': stickyTop + 'px'
 						} );
 					}
 				} else {
-					// Original non-overlap sticky positioning logic
+					// Sticky menu WITHOUT overlap - original logic.
 					if (
 						$( 'body' ).hasClass( 'no-topbar' ) ||
 						(
@@ -490,7 +545,7 @@
 						)
 					) {
 						$mh.css( 'position', 'fixed' );
-					} else if ( ! $( 'body' ).hasClass( 'no-topbar' ) &&  ! $( 'body' ).hasClass( 'topbar-out' ) ) {
+					} else if ( ! $( 'body' ).hasClass( 'no-topbar' ) && ! $( 'body' ).hasClass( 'topbar-out' ) ) {
 						$mh.css( 'position', 'absolute' );
 					}
 				}

--- a/js/north.js
+++ b/js/north.js
@@ -591,15 +591,6 @@
 						}
 					} else {
 						// Header transitions to fixed positioning while topbar remains absolute.
-
-						// Remove admin bar offset on mobile when admin bar not visible.
-						if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
-							if ( ! $wpab.northIsVisible() ) {
-								stickyTop = 0;
-							}
-						}
-
-						// Apply fixed positioning to header.
 						$mh.css( {
 							'position': 'fixed',
 							'top': adjustMastheadTop(

--- a/js/north.js
+++ b/js/north.js
@@ -459,8 +459,32 @@
 			// Sticky header shadow.
 			var smShadow = function() {
 				var scrollTop = $( window ).scrollTop();
-				var stickyThreshold = $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ? 10 : whenToStickyMh();
-				
+				var stickyThreshold;
+
+				if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
+					// For overlap pages, calculate threshold based on top bar presence.
+					if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
+						// When top bar exists, header becomes sticky after scrolling past the top bar.
+						var wpabMobile = $( window ).width() <= 600;
+						var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
+						var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
+
+						// Mobile admin bar requires different offset height.
+						if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
+							adminBarOffset = $wpab.length ? 46 : 0;
+						}
+
+						// Threshold is when we've scrolled past where the top bar ends.
+						stickyThreshold = $tb.outerHeight() + adminBarOffset - 1;
+					} else {
+						// Without top bar, use small threshold for immediate sticky behavior.
+						stickyThreshold = 10;
+					}
+				} else {
+					// Non-overlap pages use the standard calculation.
+					stickyThreshold = whenToStickyMh();
+				}
+
 				if ( scrollTop > stickyThreshold ) {
 					$( $mh ).addClass( 'floating' );
 				} else {

--- a/js/north.js
+++ b/js/north.js
@@ -388,7 +388,7 @@
 		$tb,
 		topBarHidden = false,
 	) {
-		if (topBarHidden) {
+		if ( topBarHidden ) {
 			return adminBarOffset;
 		}
 
@@ -631,7 +631,13 @@
 
 				if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
 					if ( ! $wpab.northIsVisible() ) {
-						if ( $( 'body' ).hasClass( 'no-topbar' ) || ( ! $( 'body' ).hasClass( 'no-topbar' ) &&  $( 'body' ).hasClass( 'topbar-out' ) ) ) {
+						if (
+							$( 'body' ).hasClass( 'no-topbar' ) ||
+							(
+								! $( 'body' ).hasClass( 'no-topbar' ) &&
+								topBarHidden
+							)
+						) {
 							$mh.addClass( 'mobile-sticky-menu' );
 						}
 					}

--- a/js/north.js
+++ b/js/north.js
@@ -399,19 +399,18 @@
 				var $branding = $mh.find( '.site-branding > *' ),
 					top = window.pageYOffset || document.documentElement.scrollTop;
 
-				// Check if the menu is meant to be sticky or not, and if it is apply padding/class
+				// Calculate padding scale based on scroll position (gradual transition like the logo).
+				var paddingScale = 1;
 				if ( top > 0 ) {
-					$mh.css( {
-						'padding-top': mhPadding.top * siteoriginNorth.logoScale,
-						'padding-bottom': mhPadding.bottom * siteoriginNorth.logoScale
-					} );
-
-				} else {
-					$mh.css( {
-						'padding-top': mhPadding.top,
-						'padding-bottom': mhPadding.bottom
-					} );
+					// Gradual transition over first 48px of scroll, matching logo scaling.
+					paddingScale = siteoriginNorth.logoScale + ( Math.max( 0, 48 - top ) / 48 * ( 1 - siteoriginNorth.logoScale ) );
 				}
+
+				// Apply scaled padding.
+				$mh.css( {
+					'padding-top': mhPadding.top * paddingScale,
+					'padding-bottom': mhPadding.bottom * paddingScale
+				} );
 
 				if ( $img.length ) {
 					// Are we at the top of the page?

--- a/js/north.js
+++ b/js/north.js
@@ -392,7 +392,7 @@
 			return adminBarOffset;
 		}
 
-		// Calculate the Y end position of the top bar relative to the page
+		// Calculate the Y end position of the top bar relative to the page.
 		var tbEndY = $tb.length ?
 			$tb.offset().top + $tb.outerHeight() - pageY :
 			0;

--- a/js/north.js
+++ b/js/north.js
@@ -47,14 +47,28 @@
 		} );
 	};
 
-	// Check if an element is visible in the viewport.
-	$.fn.northIsVisible = function() {
-		var rect = this[0].getBoundingClientRect();
+
+	/**
+	 * Checks if an element is visible in the viewport.
+	 *
+	 * This function optionally factors in the admin bar.
+	 *
+	 * @param {number} adminBarOffset - The height of the admin bar, if present.
+	 *
+	 * @returns {boolean} - True if the element is visible in the viewport, false otherwise.
+	 */
+	$.fn.northIsVisible = function( adminBarOffset = 32 ) {
+		const rect = this[0].getBoundingClientRect();
+
 		return (
-			rect.bottom >= 0 &&
 			rect.right >= 0 &&
-			rect.top <= ( window.innerHeight || document.documentElement.clientHeight ) &&
-			rect.left <= ( window.innerWidth || document.documentElement.clientWidth )
+			rect.bottom - adminBarOffset >= 0 &&
+			rect.top + adminBarOffset <= (
+				window.innerHeight || document.documentElement.clientHeight
+			) &&
+			rect.left <= (
+				window.innerWidth || document.documentElement.clientWidth
+			)
 		);
 	};
 

--- a/js/north.js
+++ b/js/north.js
@@ -643,9 +643,18 @@
 							topBarHidden
 						)
 					) {
-						$mh.css( 'position', 'fixed' );
-					} else if ( ! $( 'body' ).hasClass( 'no-topbar' ) && ! $( 'body' ).hasClass( 'topbar-out' ) ) {
-						$mh.css( 'position', 'absolute' );
+						$mh.css({
+							'position': 'fixed',
+							'top': adminBarOffset + 'px',
+						});
+					} else if (
+						! $( 'body' ).hasClass( 'no-topbar' ) &&
+						! topBarHidden
+					) {
+						$mh.css({
+							'position': 'absolute',
+							'top': 'auto',
+						});
 					}
 				}
 

--- a/js/north.js
+++ b/js/north.js
@@ -57,8 +57,8 @@
 	 *
 	 * @returns {boolean} - True if the element is visible in the viewport, false otherwise.
 	 */
-	$.fn.northIsVisible = function( adminBarOffset = 32 ) {
-		const rect = this[0].getBoundingClientRect();
+	$.fn.northIsVisible = function( adminBarOffset ) {
+		var rect = this[0].getBoundingClientRect();
 
 		return (
 			rect.right >= 0 &&
@@ -86,13 +86,13 @@
 	 * @returns {number} - The height of the admin bar in pixels, or 0 if the admin
 	 *                     bar is not present.
 	 */
-	const getAdminBarOffset = ( $wpab ) => {
+	var getAdminBarOffset = function( $wpab ) {
 		if ( ! $wpab.length ) {
 			return 0;
 		}
 
-		const wpabMobile = $( window ).width() <= 600;
-		let adminBarOffset = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 46;
+		var wpabMobile = $( window ).width() <= 600;
+		var adminBarOffset = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 46;
 
 
 		// On mobile, the admin bar has a fixed position so we need to scale the
@@ -382,11 +382,11 @@
 	 *
 	 * @returns {number} - The calculated top position for the masthead.
 	 */
-	const adjustMastheadTop = function(
+	var adjustMastheadTop = function(
 		pageY,
 		adminBarOffset,
 		$tb,
-		topBarHidden = false,
+		topBarHidden
 	) {
 		if ( topBarHidden ) {
 			return adminBarOffset;
@@ -411,7 +411,7 @@
 				$wpab = $( '#wpadminbar' );
 
 			var earlyOverlapPositioning = function() {
-				const adminBarOffset = getAdminBarOffset( $wpab );
+				var adminBarOffset = getAdminBarOffset( $wpab );
 
 				// Set topbar position when present.
 				if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
@@ -549,7 +549,7 @@
 					$mhs.css( 'height', $mh.outerHeight() );
 				}
 
-				const adminBarOffset = getAdminBarOffset( $wpab );
+				var adminBarOffset = getAdminBarOffset( $wpab );
 
 				var topBarHidden = false;
 				if ( $tb.length ) {

--- a/js/north.js
+++ b/js/north.js
@@ -326,6 +326,52 @@
 		var scrollOnLoad = true;
 	}
 
+	// Handle menu overlap positioning on DOMContentLoaded for CLS prevention.
+	$( document ).ready( function() {
+		if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
+			var $mh = $( '#masthead' ),
+				$tb = $( '#topbar' ),
+				$wpab = $( '#wpadminbar' );
+
+			var earlyOverlapPositioning = function() {
+				var wpabMobile = $( window ).width() <= 600;
+				var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
+				var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
+
+				// Mobile admin bar requires different offset height.
+				if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
+					adminBarOffset = $wpab.length ? 46 : 0;
+				}
+
+				// Set topbar position when present.
+				if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
+					var tbHeight = $tb.outerHeight();
+					$tb.css( {
+						'position': 'absolute',
+						'top': adminBarOffset + 'px',
+						'visibility': 'visible'
+					} );
+					// Header positioned below topbar to maintain visual hierarchy.
+					$mh.css( {
+						'position': 'absolute',
+						'top': ( adminBarOffset + tbHeight ) + 'px',
+						'visibility': 'visible'
+					} );
+				} else {
+					// Header positioned at admin bar offset when topbar absent.
+					$mh.css( {
+						'position': 'absolute',
+						'top': adminBarOffset + 'px',
+						'visibility': 'visible'
+					} );
+				}
+			};
+
+			// Run initial positioning on DOM ready.
+			earlyOverlapPositioning();
+		}
+	} );
+
 	$( window ).on( 'load', function() {
 		siteoriginNorth.logoScale = parseFloat( siteoriginNorth.logoScale );
 
@@ -395,49 +441,6 @@
 			$( window ).on( 'scroll resize', smResizeLogo );
 		}
 
-		// Handle menu overlap positioning independent of sticky menu setting.
-		if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) && ! $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
-			// Menu overlap WITHOUT sticky menu.
-			var $mh = $( '#masthead' ),
-				$tb = $( '#topbar' ),
-				$wpab = $( '#wpadminbar' );
-
-			var overlapPositioning = function() {
-				var wpabMobile = $( window ).width() <= 600;
-				var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
-				var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
-
-				// Mobile admin bar requires different offset height.
-				if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
-					adminBarOffset = $wpab.length ? 46 : 0;
-				}
-
-				// Set topbar position when present.
-				if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
-					var tbHeight = $tb.outerHeight();
-					$tb.css( {
-						'position': 'absolute',
-						'top': adminBarOffset + 'px'
-					} );
-					// Header positioned below topbar to maintain visual hierarchy.
-					$mh.css( {
-						'position': 'absolute',
-						'top': ( adminBarOffset + tbHeight ) + 'px'
-					} );
-				} else {
-					// Header positioned at admin bar offset when topbar absent.
-					$mh.css( {
-						'position': 'absolute',
-						'top': adminBarOffset + 'px'
-					} );
-				}
-			};
-
-			// Run on load and resize.
-			overlapPositioning();
-			$( window ).on( 'resize', overlapPositioning );
-		}
-
 		// Now lets do the sticky menu.
 		if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
 			var $mh = $( '#masthead' ),
@@ -504,18 +507,21 @@
 							var tbHeight = $tb.outerHeight();
 							$tb.css( {
 								'position': 'absolute',
-								'top': adminBarOffset + 'px'
+								'top': adminBarOffset + 'px',
+								'visibility': 'visible'
 							} );
 							// Header positioned below topbar to maintain visual hierarchy.
 							$mh.css( {
 								'position': 'absolute',
-								'top': ( adminBarOffset + tbHeight ) + 'px'
+								'top': ( adminBarOffset + tbHeight ) + 'px',
+								'visibility': 'visible'
 							} );
 						} else {
 							// Header positioned at admin bar offset when topbar absent.
 							$mh.css( {
 								'position': 'absolute',
-								'top': adminBarOffset + 'px'
+								'top': adminBarOffset + 'px',
+								'visibility': 'visible'
 							} );
 						}
 					} else {

--- a/js/north.js
+++ b/js/north.js
@@ -72,6 +72,38 @@
 		);
 	};
 
+	/**
+	 * Calculates the height of the WordPress admin bar, factoring in mobile
+	 * and desktop views.
+	 *
+	 * This function determines the height of the admin bar (`#wpadminbar`) if it
+	 * is present and visible. It accounts for different heights on mobile devices
+	 * and adjusts the height dynamically based on the scroll position for fixed
+	 * admin bars on mobile.
+	 *
+	 * @param {jQuery} $wpab - The jQuery object representing the admin bar element.
+	 *
+	 * @returns {number} - The height of the admin bar in pixels, or 0 if the admin
+	 *                     bar is not present.
+	 */
+	const getAdminBarOffset = ( $wpab ) => {
+		if ( ! $wpab.length ) {
+			return 0;
+		}
+
+		const wpabMobile = $( window ).width() <= 600;
+		let adminBarOffset = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 46;
+
+
+		// On mobile, the admin bar has a fixed position so we need to scale the
+		// offset based on that.
+		if ( wpabMobile && $( window ).scrollTop() > 0 ) {
+			adminBarOffset = Math.max( 0, adminBarOffset - $( window ).scrollTop() );
+		}
+
+		return adminBarOffset;
+	};
+
 	var headerHeight = function( $target, load ) {
 		var height = 0;
 
@@ -348,14 +380,7 @@
 				$wpab = $( '#wpadminbar' );
 
 			var earlyOverlapPositioning = function() {
-				var wpabMobile = $( window ).width() <= 600;
-				var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
-				var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
-
-				// Mobile admin bar requires different offset height.
-				if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
-					adminBarOffset = $wpab.length ? 46 : 0;
-				}
+				const adminBarOffset = getAdminBarOffset( $wpab );
 
 				// Set topbar position when present.
 				if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
@@ -523,19 +548,13 @@
 				if ( $tb.length && $( 'body' ).hasClass( 'topbar-out' ) && $tb.northIsVisible() ) {
 					$( 'body' ).removeClass( 'topbar-out' );
 				}
+				
+				const adminBarOffset = getAdminBarOffset( $wpab );
 
 				// Handle positioning based on overlap and sticky combination.
 				if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
 					// BOTH sticky and overlap are enabled.
 					var scrollTop = $( window ).scrollTop();
-					var wpabMobile = $( window ).width() <= 600;
-					var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
-					var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
-					
-					// Mobile admin bar requires different offset height.
-					if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
-						adminBarOffset = $wpab.length ? 46 : 0;
-					}
 
 					// Initial overlap state with absolute positioning.
 					if ( scrollTop <= 0 ) {

--- a/js/north.js
+++ b/js/north.js
@@ -477,8 +477,8 @@
 						// Threshold is when we've scrolled past where the top bar ends.
 						stickyThreshold = $tb.outerHeight() + adminBarOffset - 1;
 					} else {
-						// Without top bar, use small threshold for immediate sticky behavior.
-						stickyThreshold = 10;
+						// Without top bar, use zero threshold for seamless sticky behavior.
+						stickyThreshold = 0;
 					}
 				} else {
 					// Non-overlap pages use the standard calculation.
@@ -525,7 +525,7 @@
 					}
 
 					// Initial overlap state with absolute positioning.
-					if ( scrollTop <= 10 ) {
+					if ( scrollTop <= 0 ) {
 						// Set topbar position when present.
 						if ( $tb.length && ! $( 'body' ).hasClass( 'no-topbar' ) ) {
 							var tbHeight = $tb.outerHeight();

--- a/js/north.js
+++ b/js/north.js
@@ -398,7 +398,7 @@
 		// Now lets do the sticky menu.
 		if ( $( '#masthead' ).hasClass( 'sticky-menu' ) ) {
 			var $mh = $( '#masthead' ),
-				$mhs = $( '<div class="masthead-sentinel"></div>' ).insertAfter( $mh ),
+				$mhs = ! $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ? $( '<div class="masthead-sentinel"></div>' ).insertAfter( $mh ) : $(),
 				$tb = $( '#topbar' ),
 				$wpab = $( '#wpadminbar' );
 
@@ -412,7 +412,10 @@
 
 			// Sticky header shadow.
 			var smShadow = function() {
-				if ( $( window ).scrollTop() > whenToStickyMh() ) {
+				var scrollTop = $( window ).scrollTop();
+				var stickyThreshold = $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ? 10 : whenToStickyMh();
+				
+				if ( scrollTop > stickyThreshold ) {
 					$( $mh ).addClass( 'floating' );
 				} else {
 					$( $mh ).removeClass( 'floating' );
@@ -438,16 +441,58 @@
 					$( 'body' ).removeClass( 'topbar-out' );
 				}
 
-				if (
-					$( 'body' ).hasClass( 'no-topbar' ) ||
-					(
-						! $( 'body' ).hasClass( 'no-topbar' ) &&
-						$( 'body' ).hasClass( 'topbar-out' )
-					)
-				) {
-					$mh.css( 'position', 'fixed' );
-				} else if ( ! $( 'body' ).hasClass( 'no-topbar' ) &&  ! $( 'body' ).hasClass( 'topbar-out' ) ) {
-					$mh.css( 'position', 'absolute' );
+				// Handle hybrid positioning for menu overlap + sticky combination
+				if ( $( 'body' ).hasClass( 'page-layout-menu-overlap' ) ) {
+					var scrollTop = $( window ).scrollTop();
+					var wpabMobile = $( window ).width() <= 600;
+					var wpabHeight = $wpab.length && ! wpabMobile ? $wpab.outerHeight() : 0;
+					var tbHeight = $tb.length && siteoriginNorth.stickyTopbar ? $tb.outerHeight() : 0;
+					var adminBarOffset = $( 'body' ).hasClass( 'admin-bar' ) ? wpabHeight : 0;
+					
+					// On mobile with admin bar, use mobile-specific offset
+					if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
+						adminBarOffset = $wpab.length ? 46 : 0; // Mobile admin bar height
+					}
+
+					// Start with absolute positioning (overlap effect with transparency)
+					if ( scrollTop <= 10 ) {
+						$mh.css( {
+							'position': 'absolute',
+							'top': adminBarOffset + 'px'
+						} );
+					} else {
+						// Transition to fixed positioning (sticky effect, remove transparency)
+						var topPosition = adminBarOffset;
+						
+						// On mobile, don't offset for admin bar when scrolled (like mobile-sticky-menu)
+						if ( $( window ).width() < 601 && $( 'body' ).hasClass( 'admin-bar' ) ) {
+							if ( ! $wpab.northIsVisible() ) {
+								topPosition = 0; // No admin bar offset when scrolled on mobile
+							}
+						}
+						
+						if ( $tb.length && siteoriginNorth.stickyTopbar && $( 'body' ).hasClass( 'topbar-out' ) ) {
+							topPosition += tbHeight;
+						}
+						
+						$mh.css( {
+							'position': 'fixed',
+							'top': topPosition + 'px'
+						} );
+					}
+				} else {
+					// Original non-overlap sticky positioning logic
+					if (
+						$( 'body' ).hasClass( 'no-topbar' ) ||
+						(
+							! $( 'body' ).hasClass( 'no-topbar' ) &&
+							$( 'body' ).hasClass( 'topbar-out' )
+						)
+					) {
+						$mh.css( 'position', 'fixed' );
+					} else if ( ! $( 'body' ).hasClass( 'no-topbar' ) &&  ! $( 'body' ).hasClass( 'topbar-out' ) ) {
+						$mh.css( 'position', 'absolute' );
+					}
 				}
 
 				if ( $( 'body' ).hasClass( 'no-topbar' ) && ! $( window ).scrollTop() ) {

--- a/rtl.css
+++ b/rtl.css
@@ -269,3 +269,5 @@ textarea {
   .post-navigation .nav-next .north-icon-previous {
     float: left;
     margin: 0.25em 5px 0 0; }
+
+/*# sourceMappingURL=sass/maps/rtl.css.map */

--- a/sass/layout/_page-settings.scss
+++ b/sass/layout/_page-settings.scss
@@ -29,24 +29,38 @@ body.page-layout-stripped {
 
 .page-layout-menu-overlap {
 
+	#topbar {
+		left: 0;
+		position: absolute;
+		top: 0;
+		width: 100%;
+		z-index: 102;
+	}
+
+	// Ensure topbar uses absolute positioning when overlap enabled.
+	&:not(.sticky-menu) #topbar {
+		position: absolute;
+	}
+
 	#masthead {
 		left: 0;
-		top: 0;
 		width: 100%;
 		z-index: 101;
 	}
+
+	// CSS handles initial positioning relationships.
 
 	.masthead-sentinel {
 		display: none !important;
 	}
 
-	// Only force absolute positioning when sticky is NOT enabled
+	// Only force absolute positioning when sticky is NOT enabled.
 	&:not(.sticky-menu) #masthead {
 		position: absolute;
 	}
 
-	// Admin bar positioning for non-sticky cases
-	&:not(.sticky-menu).admin-bar #masthead {
+	// Admin bar positioning for topbar.
+	&:not(.sticky-menu).admin-bar #topbar {
 		top: 32px;
 
 		@media screen and (max-width: 782px) {
@@ -54,8 +68,39 @@ body.page-layout-stripped {
 		}
 	}
 
-	// For sticky + overlap combination, let JavaScript handle positioning
-	// but ensure initial absolute positioning for overlap effect
+	// Admin bar positioning for header when topbar present.
+	&:not(.sticky-menu).admin-bar:not(.no-topbar) #masthead {
+		top: 32px;
+
+		@media screen and (max-width: 782px) {
+			top: 46px;
+		}
+	}
+
+	// Admin bar positioning for header when no topbar.
+	&:not(.sticky-menu).admin-bar.no-topbar #masthead {
+		top: 32px;
+
+		@media screen and (max-width: 782px) {
+			top: 46px;
+		}
+	}
+
+	// Apply transparency to overlapping elements when not in sticky state.
+	#topbar:not(.floating) {
+		background: rgba(244, 244, 244, 0.975);
+	}
+
+	#masthead:not(.floating) {
+		background: rgba(250, 250, 250, 0.975);
+	}
+
+	// Topbar maintains absolute positioning regardless of sticky menu setting.
+	&.sticky-menu #topbar {
+		position: absolute;
+	}
+
+	// Header initial positioning for overlap with sticky menu enabled.
 	&.sticky-menu #masthead {
 		position: absolute;
 	}

--- a/sass/layout/_page-settings.scss
+++ b/sass/layout/_page-settings.scss
@@ -29,24 +29,35 @@ body.page-layout-stripped {
 
 .page-layout-menu-overlap {
 
-    #masthead {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        z-index: 101;
-        opacity: 0.975;
-    }
+	#masthead {
+		left: 0;
+		top: 0;
+		width: 100%;
+		z-index: 101;
+	}
 
-    .masthead-sentinel {
-        display: none !important;
-    }
+	.masthead-sentinel {
+		display: none !important;
+	}
 
-    &.admin-bar #masthead{
-        top: 32px;
+	// Only force absolute positioning when sticky is NOT enabled
+	&:not(.sticky-menu) #masthead {
+		position: absolute;
+	}
 
-        @media screen and (max-width: 782px) {
-            top: 46px;
-        }
-    }
+	// Admin bar positioning for non-sticky cases
+	&:not(.sticky-menu).admin-bar #masthead {
+		top: 32px;
+
+		@media screen and (max-width: 782px) {
+			top: 46px;
+		}
+	}
+
+	// For sticky + overlap combination, let JavaScript handle positioning
+	// but ensure initial absolute positioning for overlap effect
+	&.sticky-menu #masthead {
+		position: absolute;
+	}
+
 }

--- a/sass/layout/_page-settings.scss
+++ b/sass/layout/_page-settings.scss
@@ -35,6 +35,7 @@ body.page-layout-stripped {
 		top: 0;
 		width: 100%;
 		z-index: 102;
+		visibility: hidden; // Hidden until JS positioning complete.
 	}
 
 	// Ensure topbar uses absolute positioning when overlap enabled.
@@ -46,6 +47,7 @@ body.page-layout-stripped {
 		left: 0;
 		width: 100%;
 		z-index: 101;
+		visibility: hidden; // Hidden until JS positioning complete.
 	}
 
 	// CSS handles initial positioning relationships.

--- a/style-editor.css
+++ b/style-editor.css
@@ -7,3 +7,5 @@ Version: dev
     max-width: 1040px; }
   .block-editor-page .wp-block[data-align="full"] {
     max-width: none; }
+
+/*# sourceMappingURL=sass/maps/style-editor.css.map */

--- a/style.css
+++ b/style.css
@@ -1333,9 +1333,18 @@ body.page-layout-stripped #main.site-main {
 .page-layout-no-footer-margin #colophon {
   margin-top: 0; }
 
+.page-layout-menu-overlap #topbar {
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: 102; }
+
+.page-layout-menu-overlap:not(.sticky-menu) #topbar {
+  position: absolute; }
+
 .page-layout-menu-overlap #masthead {
   left: 0;
-  top: 0;
   width: 100%;
   z-index: 101; }
 
@@ -1345,11 +1354,32 @@ body.page-layout-stripped #main.site-main {
 .page-layout-menu-overlap:not(.sticky-menu) #masthead {
   position: absolute; }
 
-.page-layout-menu-overlap:not(.sticky-menu).admin-bar #masthead {
+.page-layout-menu-overlap:not(.sticky-menu).admin-bar #topbar {
   top: 32px; }
   @media screen and (max-width: 782px) {
-    .page-layout-menu-overlap:not(.sticky-menu).admin-bar #masthead {
+    .page-layout-menu-overlap:not(.sticky-menu).admin-bar #topbar {
       top: 46px; } }
+
+.page-layout-menu-overlap:not(.sticky-menu).admin-bar:not(.no-topbar) #masthead {
+  top: 32px; }
+  @media screen and (max-width: 782px) {
+    .page-layout-menu-overlap:not(.sticky-menu).admin-bar:not(.no-topbar) #masthead {
+      top: 46px; } }
+
+.page-layout-menu-overlap:not(.sticky-menu).admin-bar.no-topbar #masthead {
+  top: 32px; }
+  @media screen and (max-width: 782px) {
+    .page-layout-menu-overlap:not(.sticky-menu).admin-bar.no-topbar #masthead {
+      top: 46px; } }
+
+.page-layout-menu-overlap #topbar:not(.floating) {
+  background: rgba(244, 244, 244, 0.975); }
+
+.page-layout-menu-overlap #masthead:not(.floating) {
+  background: rgba(250, 250, 250, 0.975); }
+
+.page-layout-menu-overlap.sticky-menu #topbar {
+  position: absolute; }
 
 .page-layout-menu-overlap.sticky-menu #masthead {
   position: absolute; }

--- a/style.css
+++ b/style.css
@@ -2296,3 +2296,5 @@ object {
     background: #000;
     opacity: 0.1;
     border-radius: 10px; }
+
+/*# sourceMappingURL=sass/maps/style.css.map */

--- a/style.css
+++ b/style.css
@@ -1338,7 +1338,8 @@ body.page-layout-stripped #main.site-main {
   position: absolute;
   top: 0;
   width: 100%;
-  z-index: 102; }
+  z-index: 102;
+  visibility: hidden; }
 
 .page-layout-menu-overlap:not(.sticky-menu) #topbar {
   position: absolute; }
@@ -1346,7 +1347,8 @@ body.page-layout-stripped #main.site-main {
 .page-layout-menu-overlap #masthead {
   left: 0;
   width: 100%;
-  z-index: 101; }
+  z-index: 101;
+  visibility: hidden; }
 
 .page-layout-menu-overlap .masthead-sentinel {
   display: none !important; }

--- a/style.css
+++ b/style.css
@@ -1334,21 +1334,25 @@ body.page-layout-stripped #main.site-main {
   margin-top: 0; }
 
 .page-layout-menu-overlap #masthead {
-  position: absolute;
-  top: 0;
   left: 0;
+  top: 0;
   width: 100%;
-  z-index: 101;
-  opacity: 0.975; }
+  z-index: 101; }
 
 .page-layout-menu-overlap .masthead-sentinel {
   display: none !important; }
 
-.page-layout-menu-overlap.admin-bar #masthead {
+.page-layout-menu-overlap:not(.sticky-menu) #masthead {
+  position: absolute; }
+
+.page-layout-menu-overlap:not(.sticky-menu).admin-bar #masthead {
   top: 32px; }
   @media screen and (max-width: 782px) {
-    .page-layout-menu-overlap.admin-bar #masthead {
+    .page-layout-menu-overlap:not(.sticky-menu).admin-bar #masthead {
       top: 46px; } }
+
+.page-layout-menu-overlap.sticky-menu #masthead {
+  position: absolute; }
 
 /*--------------------------------------------------------------
 ## Site Masthead

--- a/woocommerce-rtl.css
+++ b/woocommerce-rtl.css
@@ -547,3 +547,5 @@
   .main-navigation .shopping-cart .shopping-cart-dropdown {
     right: auto;
     left: 0; }
+
+/*# sourceMappingURL=sass/maps/woocommerce-rtl.css.map */

--- a/woocommerce-smallscreen-rtl.css
+++ b/woocommerce-smallscreen-rtl.css
@@ -54,3 +54,5 @@
 /* Styles specific to SiteOrigin North */
 .woocommerce #main ul.products li.product {
   margin: 0 0 2.992em; }
+
+/*# sourceMappingURL=sass/maps/woocommerce-smallscreen-rtl.css.map */

--- a/woocommerce.css
+++ b/woocommerce.css
@@ -1095,3 +1095,5 @@ body:not(.no-active-sidebar) .woocommerce table.shop_table .wc-buttons .cart-but
   top: 0; }
   #topbar .demo_store .woocommerce-store-notice__dismiss-link {
     padding-left: 15px; }
+
+/*# sourceMappingURL=sass/maps/woocommerce.css.map */


### PR DESCRIPTION
 Commit 1: Add topbar background opacity setting for menu overlap

  Files: inc/settings.conf.php, inc/settings.php

  Adds a new customizer setting allowing users to control the transparency of the topbar when menu overlap is enabled. This creates a range slider (0-1) in the WordPress customizer labeled "Background Top Color Overlap Opacity" with a default value of 0.975 for
  subtle transparency. The setting is mapped to SCSS variables through the theme's settings framework, enabling users to customize how transparent the topbar appears when overlapping page content.

  Commit 2: Add menu overlap CSS positioning and transparency rules

  Files: sass/layout/_page-settings.scss, style.css

  Implements the core CSS functionality for menu overlap mode. When overlap is enabled, both topbar and header are positioned absolutely to overlap page content with proper z-index stacking (topbar: 102, header: 101). Includes comprehensive admin bar positioning
  for desktop (32px) and mobile (46px) scenarios. Applies RGBA transparency rules that make both elements semi-transparent when not in sticky state, and ensures the masthead sentinel is hidden during overlap mode to prevent spacing issues.

  Commit 3: Separate menu overlap from sticky menu logic

  Files: js/north.js

  Fixes a fundamental architectural issue where menu overlap functionality was incorrectly nested inside the sticky menu conditional block, making it only work when sticky was enabled. Restructures the JavaScript to handle four distinct scenarios:
  1. Overlap only - Standalone absolute positioning for non-sticky overlap
  2. Sticky only - Restores original sticky behavior that was accidentally removed
  3. Both enabled - Hybrid positioning where header transitions from absolute (overlap) to fixed (sticky)
  4. Neither enabled - Default static positioning
  
  --

 **Desktop Testing Combinations**

  Base States:

  1. No Overlap, No Sticky, No Topbar
  2. No Overlap, No Sticky, With Topbar
  3. No Overlap, With Sticky, No Topbar
  4. No Overlap, With Sticky, With Topbar
  5. With Overlap, No Sticky, No Topbar
  6. With Overlap, No Sticky, With Topbar
  7. With Overlap, With Sticky, No Topbar
  8. With Overlap, With Sticky, With Topbar

  Admin Bar Variants (x2):

  All above 8 combinations × 2 = 16 desktop scenarios
  - Without admin bar (logged out)
  - With admin bar (logged in)

  Total Desktop: 16 scenarios

  **Mobile Testing Combinations**

  Base States:

  1. No Overlap, No Sticky, No Topbar
  2. No Overlap, No Sticky, With Topbar
  3. No Overlap, With Sticky, No Topbar
  4. No Overlap, With Sticky, With Topbar
  5. With Overlap, No Sticky, No Topbar
  6. With Overlap, No Sticky, With Topbar
  7. With Overlap, With Sticky, No Topbar
  8. With Overlap, With Sticky, With Topbar

  Admin Bar Variants (x2):

  All above 8 combinations × 2 = 16 mobile scenarios
  - Without admin bar (logged out)
  - With admin bar (logged in - 46px offset)

  Total Mobile: 16 scenarios

  ---
  Grand Total: 32 Testing Scenarios

  Key Testing Points for Each Scenario:

  1. Initial page load - Correct positioning
  2. Scroll behavior - Proper sticky transitions
  3. Topbar transparency - RGBA when overlapping, solid when sticky
  4. Header transparency - RGBA when overlapping, solid when sticky
  5. Admin bar offset - Correct positioning with/without admin bar
  6. Z-index stacking - Proper visual hierarchy
  7. Mobile admin bar - 46px vs 32px offset handling
  8. Sentinel spacing - Correct when sticky enabled without overlap

  Critical Combinations to Prioritize:

  - Desktop logged in with overlap + sticky + topbar (most complex)
  - Mobile logged in with overlap + sticky + topbar (most complex mobile)
  - Desktop/Mobile with sticky but no overlap (ensure we didn't break original)
  - Desktop/Mobile with overlap but no sticky (new standalone feature)
